### PR TITLE
fix syncfifo full indication

### DIFF
--- a/ramlib/rtl/la_syncfifo.v
+++ b/ramlib/rtl/la_syncfifo.v
@@ -51,7 +51,7 @@ module la_syncfifo
    //############################
 
    assign wr_full     = (chaosfull & chaosmode) |
-			{wr_addr[AW], wr_addr[AW-1:0]} == rd_addr[AW-1:0];
+			{~wr_addr[AW], wr_addr[AW-1:0]} == rd_addr[AW:0];
 
    assign rd_empty    = wr_addr[AW:0] == rd_addr[AW:0];
 


### PR DESCRIPTION
When using an extra bit [AW] then the condition for full/empty should be the following:
full - when all bits are the same and AW is different between rd and wr pointers
empty - when all bits are the same and AW is the same between rd and wr pointers

In the current logic the full was incorrect which led to full always being asserted from reset.