### PR TITLE
change to verilator compatible code

### DIFF
--- a/ramlib/rtl/la_spram.v
+++ b/ramlib/rtl/la_spram.v
@@ -49,10 +49,16 @@ module la_spram
    integer 	      i;
 
    // Write port
+//   always @(posedge clk)
+//     for (i=0;i<DW;i=i+1)
+//       if (ce & we & wmask[i])
+//         ram[addr[AW-1:0]][i] <= din[i];
+
+   // Re-writing as a mux for verilator
    always @(posedge clk)
-     for (i=0;i<DW;i=i+1)
-       if (ce & we & wmask[i])
-         ram[addr[AW-1:0]][i] <= din[i];
+     if (ce & we)
+       ram[addr[AW-1:0]] <= din[DW-1:0]       & wmask[DW-1:0] |
+                            ram[addr[AW-1:0]] & ~wmask[DW-1:0];
 
    // Read Port
    always @ (posedge clk)


### PR DESCRIPTION
This PR fixes the following error in verilator:
Unsupported: Delayed assignment to array inside for loops (non-delayed is ok - see docs)
   55 |          ram[addr[AW-1:0]][i] <= din[i];
      |                               ^~
                    ... For error description see https://verilator.org/warn/BLKLOOPINIT?v=5.008

The fix is replacing the if inside the loop to a mux written as a vector:
   always @(posedge clk)
     if (ce & we)
       ram[addr[AW-1:0]] <= din[DW-1:0]       & wmask[DW-1:0] |
                            ram[addr[AW-1:0]] & ~wmask[DW-1:0];
