### PR TITLE
replace tran with pt block

### DIFF
--- a/iolib/rtl/la_ioanalog.v
+++ b/iolib/rtl/la_ioanalog.v
@@ -34,22 +34,11 @@ module la_ioanalog
    assign aio[1] = pad;
    assign aio[2] = pad;
 
-`elsif YOSYS
-   assign pad=aio[0];
-   assign pad=aio[1];
-   assign pad=aio[2];
-   assign aio[0] = pad;
-   assign aio[1] = pad;
-   assign aio[2] = pad;
-
 `else
-
    // replace tran with alias in order to work in Yosis
    la_pt la_pt_0(pad,aio[0]);
    la_pt la_pt_1(pad,aio[1]);
    la_pt la_pt_2(pad,aio[2]);
-//   tran t1(pad, aio[1]);
-//   tran t2(pad, aio[2]);
 `endif
 
 endmodule

--- a/iolib/rtl/la_ioshort.v
+++ b/iolib/rtl/la_ioshort.v
@@ -22,9 +22,6 @@ module la_ioshort
    // Using direction to break the loop
    assign a = ~a2b ? b : 1'bz;
    assign b = a2b  ? a : 1'bz;
-`elsif YOSYS
-   assign a = b;
-   assign b = a;
 `else
    // single port pass through short/hack
    la_pt la_pt(a,b);


### PR DESCRIPTION
Yosis does not support tran so replacing with pt module (same as ioshort).
Peter - please confirm it works and we'll merge.