### PR TITLE
Register read side output of async fifo

### DIFF
--- a/ramlib/rtl/la_asyncfifo.v
+++ b/ramlib/rtl/la_asyncfifo.v
@@ -39,7 +39,7 @@ module la_asyncfifo
     // read port
     input 	      rd_clk,
     input 	      rd_nreset,
-    output [DW-1:0]   rd_dout, // output data (next cycle)
+    output reg [DW-1:0]   rd_dout, // output data (next cycle)
     input 	      rd_en, // read fifo
     output reg 	      rd_empty, // fifo is empty
     // Power signals
@@ -157,7 +157,9 @@ module la_asyncfifo
        ram[wr_binptr[AW-1:0]] <= wr_din[DW-1:0];
 
    // Read port (FIFO output)
-   assign rd_dout[DW-1:0] = ram[rd_binptr[AW-1:0]];
+   always @(posedge rd_clk)
+    if (rd_en)
+      rd_dout[DW-1:0] <= ram[rd_binptr[AW-1:0]];
 
    //############################
    // Randomly Asserts FIFO full


### PR DESCRIPTION
This PR updates `la_asyncfifo` to register the read data out with respect to the read clock. I'd like some feedback on this since I'm not 100% sure this change is correct/intended, but I believe this is how this should be written to properly infer a dual-port SRAM. 

I've noticed Vivado occasionally having issues with hold violations on paths coming out from this module, and I think this change helps alleviate those problems. This also appears to be functionally correct in my testing (which uses this module via `umi_fifo`), and seems to match the intent of the comment on the `rd_dout` port definition ("next cycle"). 