### PR TITLE
Fix clkmux lock

### DIFF
--- a/stdlib/rtl/la_clkmux2.v
+++ b/stdlib/rtl/la_clkmux2.v
@@ -30,10 +30,10 @@ module la_clkmux2
                       .z(en[1:0]));
 
    // synchronizers (2)
-   la_dsync_rst isync[1:0] (.clk({clk1,clk0}),
-                            .nreset({nreset,nreset}),
-                            .in(en[1:0]),
-                            .out(ensync[1:0]));
+   la_drsync isync[1:0] (.clk({clk1,clk0}),
+                         .nreset({nreset,nreset}),
+                         .in(en[1:0]),
+                         .out(ensync[1:0]));
 
    // glith free clock gate (2)
    la_and2 igate[1:0] (.a({clk1,clk0}),


### PR DESCRIPTION
la_clkmux2 requires a reset for the enable signals to prevent a deadlock.
Without an async reset for the en_sync flops the mux can wakeup locked if one of the clocks is not toggling and the enable for that clock woke up high. 
This is an example scenario:
- clk0 is toggling
- clk1 is not
- ensync1 synchronizer powered up in state 1
- as a result mask[0] will be 0, gating clk0
- since clk1 does not toggle en_sync[1] will never clear 

The fix is replacing en_sync from la_dsync to la_drsync.
Side note - the same already exists in la_clkmux4.