### PR TITLE
Force clock [0] propagation during reset

### DIFF
--- a/stdlib/rtl/la_clkmux2.v
+++ b/stdlib/rtl/la_clkmux2.v
@@ -18,7 +18,9 @@ module la_clkmux2
 
    wire [1:0] maskb;
    wire [1:0] en;
+   wire       enb;
    wire [1:0] ensync;
+   wire       ensyncb;
    wire [1:0] clkg;
 
    // invert mask (2)
@@ -29,11 +31,15 @@ module la_clkmux2
                       .b(maskb[1:0]),
                       .z(en[1:0]));
 
+   la_inv ienb (.a(en[0]), .z(enb));
+
    // synchronizers (2)
    la_drsync isync[1:0] (.clk({clk1,clk0}),
                          .nreset({nreset,nreset}),
-                         .in(en[1:0]),
-                         .out(ensync[1:0]));
+                         .in({en[1],enb}),
+                         .out({ensync[1],ensyncb}));
+
+   la_inv iensync (.a(ensyncb), .z(ensync[0]));
 
    // glith free clock gate (2)
    la_clkicgand igate[1:0] (.clk({clk1,clk0}),

--- a/stdlib/rtl/la_clkmux4.v
+++ b/stdlib/rtl/la_clkmux4.v
@@ -23,7 +23,9 @@ module la_clkmux4
    wire [3:0] mask;
    wire [3:0] maskb;
    wire [3:0] en;
+   wire       enb;
    wire [3:0] ensync;
+   wire       ensyncb;
    wire [3:0] clkg;
    wire [3:0] nreset_sync;
 
@@ -41,11 +43,15 @@ module la_clkmux4
                       .b(maskb[3:0]),
                       .z(en[3:0]));
 
+   la_inv ienb (.a(en[0]), .z(enb));
+
    // data synchronizer with reset (since clocks aren't guaranteed)
    la_drsync idrsync[3:0] (.clk({clk3,clk2,clk1,clk0}),
                            .nreset({4{nreset}}),
-                           .in(en[3:0]),
-                           .out(ensync[3:0]));
+                           .in({en[3:1],enb}),
+                           .out({ensync[3:1],ensyncb}));
+
+   la_inv iensync (.a(ensyncb), .z(ensync[0]));
 
    // glith free clock gate (4)
    la_clkicgand igate[3:0] (.clk({clk3,clk2,clk1,clk0}),


### PR DESCRIPTION
The current implementation of the clock mux has the reset value of both enables to zero.
As a result, even if the sel is asserted during reset and the clock is toggling, no clock will be passing through.
This can be risky if the design requires clock toggling during reset to allow the reset to propagate.

The change sets the reset value of ensync[0] to 1 and therefore opens clock 0 path during reset.
