### PR TITLE
Update AW localparam in la_asyncfifo

### DIFF
--- a/lambdalib/ramlib/rtl/la_asyncfifo.v
+++ b/lambdalib/ramlib/rtl/la_asyncfifo.v
@@ -50,8 +50,7 @@ module la_asyncfifo #(
 );
 
     // local params
-    // The last part is to support DEPTH of 1
-    localparam AW = $clog2(DEPTH) + {31'h0, (DEPTH == 1)};
+    localparam AW = (DEPTH == 1) ? 1 : $clog2(DEPTH);
 
     // local wires
     reg  [AW:0] wr_grayptr;


### PR DESCRIPTION
Functionally equivalent to the current definition, but avoids an issue in Surelog 1.82 that prevents `la_drsync` from being elaborated.  I think it's also a little clearer.