### PR TITLE
Improving iolib cells

### DIFF
--- a/lambdalib/iolib/rtl/la_iobidir.v
+++ b/lambdalib/iolib/rtl/la_iobidir.v
@@ -26,14 +26,132 @@ module la_iobidir
     output            z,      // output to core
     input             ie,     // input enable, 1 = active
     input             oe,     // output enable, 1 = active
+    input             pe,     // pull enable, 1 = enable
+    input             ps,     // pull select, 1 = pullup, 0 = pulldown
     inout [RINGW-1:0] ioring, // generic io ring
     input [CFGW-1:0]  cfg     // generic config interface
     );
 
-   // to core
-    assign z   = ie ? pad : 1'b0;
+   assign z   = ie ? pad : 1'b0;
+   assign pad = oe ? a : 1'bz;
 
-    // to pad
-    assign pad = oe ? a : 1'bz;
+`ifndef VERILATOR
+   rnmos #1 (pad, vssio, pe & ~ps); // weak pulldown
+   rnmos #1 (pad, vddio, pe & ps); // weak pullup
+`endif
 
 endmodule
+
+//######################################################################
+// MINIMAL TESTBENCH
+//######################################################################
+
+`ifdef TB_LA_IOBIDIR
+
+module tb();
+
+   parameter CFGW = 16;
+   parameter RINGW = 8;
+
+   localparam PERIOD = 10;
+   localparam TIMEOUT = PERIOD  * 200;
+
+   reg        drive;
+   reg        data;
+
+   // control block
+   initial
+     begin
+        $timeformat(-9, 0, " ns", 20);
+        $dumpfile("dump.vcd");
+        $dumpvars(0, tb);
+        #(TIMEOUT)
+        $finish;
+     end
+
+   // test program
+   initial
+     begin
+        // inactive
+        a = 1'bx;
+        ie = 1'b0;
+        oe = 1'b0;
+        pe = 1'b0;
+        ps = 1'b0;
+        cfg = 'b0;
+        drive = 1'b0;
+        data = 1'b0;
+        // with pulldown
+        #(PERIOD)
+        pe = 1'b1;
+        ps = 1'b0;
+        // with pullup
+        #(PERIOD)
+        ps = 1'b1;
+        // driven input with pullup
+        #(PERIOD)
+        ie = 1'b1;
+        drive = 1'b1;
+        data = 1'b0;
+        #(PERIOD)
+        data = 1'b1;
+        // output
+        #(PERIOD)
+        drive = 1'b0;
+        oe = 1'b1;
+        a = 1'b0;
+        #(PERIOD)
+        a = 1'b1;
+        // conflict
+        drive = 1'b1;
+        data = 1'b0;
+     end
+
+   assign vss   = 1'b0;
+   assign vssio = 1'b0;
+   assign vdd   = 1'b1;
+   assign vddio = 1'b1;
+
+   assign pad = drive ? data : 1'bz;
+
+   /*AUTOREGINPUT*/
+   // Beginning of automatic reg inputs (for undeclared instantiated-module inputs)
+   reg                  a;
+   reg [CFGW-1:0]       cfg;
+   reg                  ie;
+   reg                  oe;
+   reg                  pe;
+   reg                  ps;
+   // End of automatics
+   /*AUTOWIRE*/
+   // Beginning of automatic wires (for undeclared instantiated-module outputs)
+   wire [RINGW-1:0]     ioring;
+   wire                 pad;
+   wire                 vdd;
+   wire                 vddio;
+   wire                 vss;
+   wire                 vssio;
+   wire                 z;
+   // End of automatics
+
+   la_iobidir
+     la_iobidir(/*AUTOINST*/
+                // Outputs
+                .z              (z),
+                // Inouts
+                .pad            (pad),
+                .vdd            (vdd),
+                .vss            (vss),
+                .vddio          (vddio),
+                .vssio          (vssio),
+                .ioring         (ioring[RINGW-1:0]),
+                // Inputs
+                .a              (a),
+                .ie             (ie),
+                .oe             (oe),
+                .pe             (pe),
+                .ps             (ps),
+                .cfg            (cfg[CFGW-1:0]));
+
+endmodule
+`endif

--- a/lambdalib/iolib/rtl/la_ioinput.v
+++ b/lambdalib/iolib/rtl/la_ioinput.v
@@ -23,6 +23,7 @@ module la_ioinput
     inout             vssio, // io ground
     // core facing signals
     output            z,     // output to core
+    input             ie,    // input enable, 1 = active
     input             pe,    // pull enable, 1=enable
     input             ps,    // pull select, 1=pullup, 0=pulldown
     input [CFGW-1:0]  cfg,   // generic config interface
@@ -30,7 +31,7 @@ module la_ioinput
     inout [RINGW-1:0] ioring // generic ioring interface
     );
 
-   assign z = pad;
+   assign z = ie ? pad : 1'b0;
 
 `ifndef VERILATOR
    if(PROP!="FIXED") begin

--- a/lambdalib/iolib/rtl/la_ioinput.v
+++ b/lambdalib/iolib/rtl/la_ioinput.v
@@ -10,8 +10,9 @@
  *************************************************************************/
 module la_ioinput
   #(
-    parameter PROP = "DEFAULT", // cell property
+    parameter PROP = "DEFAULT", // "FIXED" ignores all ctrl inputs
     parameter SIDE = "NO",      // "NO", "SO", "EA", "WE"
+    parameter CFGW = 16,        // width of config bus
     parameter RINGW = 8         // width of io ring
     )
    (// io pad signals
@@ -22,13 +23,20 @@ module la_ioinput
     inout             vssio, // io ground
     // core facing signals
     output            z,     // output to core
+    input             pe,    // pull enable, 1=enable
+    input             ps,    // pull select, 1=pullup, 0=pulldown
+    input [CFGW-1:0]  cfg,   // generic config interface
+    // io ring
     inout [RINGW-1:0] ioring // generic ioring interface
     );
 
    assign z = pad;
 
 `ifndef VERILATOR
-   rnmos #1 (pad, vssio, 1'b1); // weak pulldown
+   if(PROP!="FIXED") begin
+      rnmos #1 (pad, vssio, pe & ~ps); // weak pulldown
+      rnmos #1 (pad, vddio, pe & ps); // weak pullup
+   end
 `endif
 
 endmodule

--- a/lambdalib/iolib/rtl/la_ioinput.v
+++ b/lambdalib/iolib/rtl/la_ioinput.v
@@ -12,23 +12,23 @@ module la_ioinput
   #(
     parameter PROP = "DEFAULT", // cell property
     parameter SIDE = "NO",      // "NO", "SO", "EA", "WE"
-    parameter CFGW = 16,        // width of core config bus
     parameter RINGW = 8         // width of io ring
     )
    (// io pad signals
-    inout             pad,    // input pad
-    inout             vdd,    // core supply
-    inout             vss,    // core ground
-    inout             vddio,  // io supply
-    inout             vssio,  // io ground
+    inout             pad,   // input pad
+    inout             vdd,   // core supply
+    inout             vss,   // core ground
+    inout             vddio, // io supply
+    inout             vssio, // io ground
     // core facing signals
-    output            z,      // output to core
-    input             ie,     // input enable, 1 = active
-    inout [RINGW-1:0] ioring, // generic ioring interface
-    input [CFGW-1:0]  cfg     // generic config interface
+    output            z,     // output to core
+    inout [RINGW-1:0] ioring // generic ioring interface
     );
 
-   // to core
-   assign z = ie ? pad : 1'b0;
+   assign z = pad;
+
+`ifndef VERILATOR
+   rnmos #1 (pad, vssio, 1'b1); // weak pulldown
+`endif
 
 endmodule

--- a/lambdalib/padring/rtl/la_iopadring.v
+++ b/lambdalib/padring/rtl/la_iopadring.v
@@ -62,6 +62,8 @@ module la_iopadring
     input [NO_NPINS-1:0]           no_a,      // input from core
     input [NO_NPINS-1:0]           no_ie,     // input enable, 1 = active
     input [NO_NPINS-1:0]           no_oe,     // output enable, 1 = active
+    input [NO_NPINS-1:0]           no_pe,     // pull enable, 1 = enable
+    input [NO_NPINS-1:0]           no_ps,     // pull select, 1 = pullup
     input [NO_NPINS*CFGW-1:0]      no_cfg,    // generic config interface
     inout [NO_NSECTIONS-1:0]       no_vdd,    // core supply
     inout [NO_NSECTIONS-1:0]       no_vddio,  // io/analog supply
@@ -75,6 +77,8 @@ module la_iopadring
     input [EA_NPINS-1:0]           ea_a,
     input [EA_NPINS-1:0]           ea_ie,
     input [EA_NPINS-1:0]           ea_oe,
+    input [EA_NPINS-1:0]           ea_pe,
+    input [EA_NPINS-1:0]           ea_ps,
     input [EA_NPINS*CFGW-1:0]      ea_cfg,
     inout [EA_NSECTIONS-1:0]       ea_vdd,
     inout [EA_NSECTIONS-1:0]       ea_vddio,
@@ -88,6 +92,8 @@ module la_iopadring
     input [SO_NPINS-1:0]           so_a,
     input [SO_NPINS-1:0]           so_ie,
     input [SO_NPINS-1:0]           so_oe,
+    input [SO_NPINS-1:0]           so_pe,
+    input [SO_NPINS-1:0]           so_ps,
     input [SO_NPINS*CFGW-1:0]      so_cfg,
     inout [SO_NSECTIONS-1:0]       so_vdd,
     inout [SO_NSECTIONS-1:0]       so_vddio,
@@ -101,6 +107,8 @@ module la_iopadring
     input [WE_NPINS-1:0]           we_a,
     input [WE_NPINS-1:0]           we_ie,
     input [WE_NPINS-1:0]           we_oe,
+    input [WE_NPINS-1:0]           we_pe,
+    input [WE_NPINS-1:0]           we_ps,
     input [WE_NPINS*CFGW-1:0]      we_cfg,
     inout [WE_NSECTIONS-1:0]       we_vdd,
     inout [WE_NSECTIONS-1:0]       we_vddio,
@@ -133,6 +141,8 @@ module la_iopadring
            .a      (no_a),
            .ie     (no_ie),
            .oe     (no_oe),
+           .pe     (no_pe),
+           .ps     (no_ps),
            .cfg    (no_cfg));
 
    // EAST
@@ -158,6 +168,8 @@ module la_iopadring
           .a      (ea_a),
           .ie     (ea_ie),
           .oe     (ea_oe),
+          .pe     (ea_pe),
+          .ps     (ea_ps),
           .cfg    (ea_cfg));
 
    // WEST
@@ -183,6 +195,8 @@ module la_iopadring
           .a      (we_a),
           .ie     (we_ie),
           .oe     (we_oe),
+          .pe     (we_pe),
+          .ps     (we_ps),
           .cfg    (we_cfg));
 
    // SOUTH
@@ -208,6 +222,8 @@ module la_iopadring
            .a      (so_a),
            .ie     (so_ie),
            .oe     (so_oe),
+           .pe     (so_pe),
+           .ps     (so_ps),
            .cfg    (so_cfg));
 
 endmodule
@@ -298,6 +314,8 @@ module tb();
     .\(.*\)_a           ({NPINS{1'b0}}),
     .\(.*\)_ie          ({NPINS{1'b1}}),
     .\(.*\)_oe          ({NPINS{1'b0}}),
+    .\(.*\)_ps          ({NPINS{1'b0}}),
+    .\(.*\)_pe          ({NPINS{1'b1}}),
     .\(.*\)_cfg         ({CFGW*NPINS{1'b0}}),
     .\(.*\)_vdd         (\1_vdd[NSECTIONS-1:0]),
     .\(.*\)_vddio       (\1_vddio[NSECTIONS-1:0]),
@@ -364,18 +382,26 @@ module tb();
                  .no_a                  ({NPINS{1'b0}}),         // Templated
                  .no_ie                 ({NPINS{1'b1}}),         // Templated
                  .no_oe                 ({NPINS{1'b0}}),         // Templated
+                 .no_pe                 ({NPINS{1'b1}}),         // Templated
+                 .no_ps                 ({NPINS{1'b0}}),         // Templated
                  .no_cfg                ({CFGW*NPINS{1'b0}}),    // Templated
                  .ea_a                  ({NPINS{1'b0}}),         // Templated
                  .ea_ie                 ({NPINS{1'b1}}),         // Templated
                  .ea_oe                 ({NPINS{1'b0}}),         // Templated
+                 .ea_pe                 ({NPINS{1'b1}}),         // Templated
+                 .ea_ps                 ({NPINS{1'b0}}),         // Templated
                  .ea_cfg                ({CFGW*NPINS{1'b0}}),    // Templated
                  .so_a                  ({NPINS{1'b0}}),         // Templated
                  .so_ie                 ({NPINS{1'b1}}),         // Templated
                  .so_oe                 ({NPINS{1'b0}}),         // Templated
+                 .so_pe                 ({NPINS{1'b1}}),         // Templated
+                 .so_ps                 ({NPINS{1'b0}}),         // Templated
                  .so_cfg                ({CFGW*NPINS{1'b0}}),    // Templated
                  .we_a                  ({NPINS{1'b0}}),         // Templated
                  .we_ie                 ({NPINS{1'b1}}),         // Templated
                  .we_oe                 ({NPINS{1'b0}}),         // Templated
+                 .we_pe                 ({NPINS{1'b1}}),         // Templated
+                 .we_ps                 ({NPINS{1'b0}}),         // Templated
                  .we_cfg                ({CFGW*NPINS{1'b0}}));   // Templated
 
 endmodule

--- a/lambdalib/padring/rtl/la_ioside.v
+++ b/lambdalib/padring/rtl/la_ioside.v
@@ -100,6 +100,9 @@ module la_ioside
                  .pad(pad[CELLMAP[(i*40)+:8]]),
                  // core signalas
                  .z(zp[CELLMAP[(i*40)+:8]]),
+                 .pe(pe[CELLMAP[(i*40)+:8]]),
+                 .ps(ps[CELLMAP[(i*40)+:8]]),
+                 .cfg(cfg[CELLMAP[(i*40)+:8]*CFGW+:CFGW]),
                  // supplies
                  .vss(vss),
                  .vdd(vdd[CELLMAP[(i*40+24)+:8]]),

--- a/lambdalib/padring/rtl/la_ioside.v
+++ b/lambdalib/padring/rtl/la_ioside.v
@@ -95,6 +95,7 @@ module la_ioside
           begin : ginput
              la_ioinput #(.SIDE(SIDE),
                           .PROP(CELLMAP[(i*40+32)+:8]),
+                          .CFGW(CFGW),
                           .RINGW(RINGW))
              i0 (// pad
                  .pad(pad[CELLMAP[(i*40)+:8]]),

--- a/lambdalib/padring/rtl/la_ioside.v
+++ b/lambdalib/padring/rtl/la_ioside.v
@@ -1,4 +1,4 @@
-/*****************************************************************************
+/**************************************************************************
  * Function: Padring Side Module
  * Copyright: Lambda Project Authors. All rights Reserved.
  * License:  MIT (see LICENSE file in Lambda repository)
@@ -7,7 +7,7 @@
  *
  * See "../README.md" for complete information
  *
- * -------------------------------------------------------------------------
+ * -----------------------------------------------------------------------
  *
  *
  * CELLMAP[39:0] = {PROP[7:0],SECTION[7:0],CELL[7:0],COMP[7:0],PIN[7:0]}
@@ -27,7 +27,7 @@
  * CELLMAP[79:0] = {{NULL,  NULL, LA_RXDIFF, PIN_RXN, PIN_RXP}
  *                  {NULL,  NULL, LA_BIDIR,  NULL,    PIN_IO0}}
  *
- ****************************************************************************/
+ *************************************************************************/
 
 module la_ioside
   #(// per side parameters
@@ -48,6 +48,8 @@ module la_ioside
     input [NPINS-1:0]           a,     // input from core
     input [NPINS-1:0]           ie,    // input enable, 1 = active
     input [NPINS-1:0]           oe,    // output enable, 1 = active
+    input [NPINS-1:0]           pe,    // pull enable, 1 = enable
+    input [NPINS-1:0]           ps,    // pull select, 1 = pullup
     input [NPINS*CFGW-1:0]      cfg,   // generic config interface
     // supplies/ring (per cell)
     inout                       vss,   // common ground
@@ -77,6 +79,8 @@ module la_ioside
                  .a(a[CELLMAP[(i*40)+:8]]),
                  .ie(ie[CELLMAP[(i*40)+:8]]),
                  .oe(oe[CELLMAP[(i*40)+:8]]),
+                 .pe(pe[CELLMAP[(i*40)+:8]]),
+                 .ps(ps[CELLMAP[(i*40)+:8]]),
                  .cfg(cfg[CELLMAP[(i*40)+:8]*CFGW+:CFGW]),
                  // supplies
                  .vss(vss),
@@ -97,7 +101,6 @@ module la_ioside
                  .pad(pad[CELLMAP[(i*40)+:8]]),
                  // core signalas
                  .z(zp[CELLMAP[(i*40)+:8]]),
-                 .ie(ie[CELLMAP[(i*40)+:8]]),
                  .cfg(cfg[CELLMAP[(i*40)+:8]*CFGW+:CFGW]),
                  // supplies
                  .vss(vss),

--- a/lambdalib/padring/rtl/la_ioside.v
+++ b/lambdalib/padring/rtl/la_ioside.v
@@ -95,13 +95,11 @@ module la_ioside
           begin : ginput
              la_ioinput #(.SIDE(SIDE),
                           .PROP(CELLMAP[(i*40+32)+:8]),
-                          .CFGW(CFGW),
                           .RINGW(RINGW))
              i0 (// pad
                  .pad(pad[CELLMAP[(i*40)+:8]]),
                  // core signalas
                  .z(zp[CELLMAP[(i*40)+:8]]),
-                 .cfg(cfg[CELLMAP[(i*40)+:8]*CFGW+:CFGW]),
                  // supplies
                  .vss(vss),
                  .vdd(vdd[CELLMAP[(i*40+24)+:8]]),

--- a/lambdalib/padring/rtl/la_ioside.v
+++ b/lambdalib/padring/rtl/la_ioside.v
@@ -74,7 +74,7 @@ module la_ioside
                           .RINGW(RINGW))
              i0 (// pad
                  .pad(pad[CELLMAP[(i*40)+:8]]),
-                 // core signalas
+                 // core signals
                  .z(zp[CELLMAP[(i*40)+:8]]),
                  .a(a[CELLMAP[(i*40)+:8]]),
                  .ie(ie[CELLMAP[(i*40)+:8]]),
@@ -99,8 +99,9 @@ module la_ioside
                           .RINGW(RINGW))
              i0 (// pad
                  .pad(pad[CELLMAP[(i*40)+:8]]),
-                 // core signalas
+                 // core signals
                  .z(zp[CELLMAP[(i*40)+:8]]),
+                 .ie(ie[CELLMAP[(i*40)+:8]]),
                  .pe(pe[CELLMAP[(i*40)+:8]]),
                  .ps(ps[CELLMAP[(i*40)+:8]]),
                  .cfg(cfg[CELLMAP[(i*40)+:8]*CFGW+:CFGW]),
@@ -120,7 +121,7 @@ module la_ioside
                            .RINGW(RINGW))
              i0 (// pad
                  .pad(pad[CELLMAP[(i*40)+:8]]),
-                 // core signalas
+                 // core signals
                  .aio(aio[CELLMAP[(i*40)+:8]*3+:3]),
                  // supplies
                  .vss(vss),


### PR DESCRIPTION
 **Making input buffer "bullet proof"**
 - For some signals like reset and certain static strap signals, we really can't afford to make a mistake. Since io cell modeling and simulation of tristate io buffer isn't always perfect, we want to make sure that the design is correct by construction as much as possible for these buffers. The bidir signal is very configurable and the cfg bus is generic per library (increasing the chance of a catastrophic mistake).
 - This input buffer hard codes all choices in teh abstracted library, minimizing the chance that the user/designer makes a mistake. The designer of the lambdapdk still needs to get the signal mapping correct, but this only has to be done once per port, not for every design.
 - Confident designers can always use the bidir cells and tie off signals to the grnd/power as appropriate for input cells that need more flexibility.

**Making bidir cell more robust**
- Making the pull select and pull enable signal hard coded signals instead of the generic cfg bus. Much more intutituve for the user and a less leakly abstractiton.
- Adding a simple minimalist testbench
- Adding modeling of weak pull up and pulldowns

