### PR TITLE
Fix Verilator Warnings

### DIFF
--- a/lambdalib/ramlib/rtl/la_dpram.v
+++ b/lambdalib/ramlib/rtl/la_dpram.v
@@ -53,7 +53,7 @@ module la_dpram #(
         .PROP       (PROP),
         .CTRLW      (CTRLW),
         .TESTW      (TESTW)
-    ) ram (
+    ) dpram (
         .wr_clk     (wr_clk),
         .wr_ce      (wr_ce),
         .wr_we      (wr_we),

--- a/lambdalib/ramlib/rtl/la_dpram.v
+++ b/lambdalib/ramlib/rtl/la_dpram.v
@@ -53,7 +53,7 @@ module la_dpram #(
         .PROP       (PROP),
         .CTRLW      (CTRLW),
         .TESTW      (TESTW)
-    ) dpram (
+    ) memory (
         .wr_clk     (wr_clk),
         .wr_ce      (wr_ce),
         .wr_we      (wr_we),

--- a/lambdalib/ramlib/rtl/la_spram.v
+++ b/lambdalib/ramlib/rtl/la_spram.v
@@ -49,7 +49,7 @@ module la_spram #(
         .PROP   (PROP),
         .CTRLW  (CTRLW),
         .TESTW  (TESTW)
-    ) ram (
+    ) spram (
         .clk    (clk),
         .ce     (ce),
         .we     (we),

--- a/lambdalib/ramlib/rtl/la_spram.v
+++ b/lambdalib/ramlib/rtl/la_spram.v
@@ -49,7 +49,7 @@ module la_spram #(
         .PROP   (PROP),
         .CTRLW  (CTRLW),
         .TESTW  (TESTW)
-    ) spram (
+    ) memory (
         .clk    (clk),
         .ce     (ce),
         .we     (we),


### PR DESCRIPTION
This fix differentiates names of ram instances from ram registers in la_*ram_impl to prevent Verilator warnings.