### PR TITLE
Removing DIFF parameter in la_odiff

### DIFF
--- a/lambdalib/auxlib/rtl/la_idiff.v
+++ b/lambdalib/auxlib/rtl/la_idiff.v
@@ -6,8 +6,7 @@
 
 module la_idiff
   #(
-    parameter PROP = "DEFAULT",
-    parameter DIFF = 0         // differential buffer if value > 0
+    parameter PROP = "DEFAULT"
     )
    (
     input  in, // positive input
@@ -15,10 +14,7 @@ module la_idiff
     output z // output
     );
 
-   if(DIFF)
-     assign z = (in & ~inb)  | // for proper diff inputs
-                (~in & ~inb);  // fail on non diff input
-   else
-     assign z = in;
+   assign z = (in & ~inb)  | // for proper diff inputs
+              (~in & ~inb);  // fail on non diff input
 
 endmodule

--- a/lambdalib/auxlib/rtl/la_odiff.v
+++ b/lambdalib/auxlib/rtl/la_odiff.v
@@ -6,8 +6,7 @@
 
 module la_odiff
   #(
-    parameter PROP = "DEFAULT",
-    parameter DIFF = 0         // differential buffer if value > 0
+    parameter PROP = "DEFAULT"
     )
    (
     input  in, // input
@@ -15,14 +14,7 @@ module la_odiff
     output zb // inverted output
     );
 
-   if(DIFF)
-     begin
-        assign z = in;
-        assign zb = ~in;
-     end
-   else
-     begin
-        assign z = in;
-        assign zb = 1'b0;
-     end
+   assign z = in;
+   assign zb = ~in;
+
 endmodule


### PR DESCRIPTION
- Didn't make sense
- A cell is either differential or it's not, should not be part of a differential cell generator...