### PR TITLE
Cleaning up naming and adding a model to PLL wrapper

### DIFF
--- a/lambdalib/analoglib/la_pll/rtl/la_pll.v
+++ b/lambdalib/analoglib/la_pll/rtl/la_pll.v
@@ -16,38 +16,38 @@
  * a problem in real designs.
  *
  *************************************************************************/
-module la_pll  #(parameter PROP = "",    // cell property
-                 parameter NIN = 1,      // number of input reference clocks
-                 parameter NOUT = 1,     // number of output clocks
-                 parameter DIVINW = 8,   // reference divider width
-                 parameter DIVFBW = 8,   // feedback divider width
-                 parameter DIVPOSTW = 8, // post feedback divider width
-                 parameter PHASEW = 8,   // phase shift adjust width
-                 parameter CW = 1,       // control vector width
-                 parameter SW = 1        // status vector width
+module la_pll  #(parameter PROP = "",   // cell property
+                 parameter NIN = 1,     // number of input reference clocks
+                 parameter NOUT = 1,    // number of output clocks
+                 parameter DIVINW = 8,  // iunpyt divider width
+                 parameter DIVFBW = 8,  // feedback divider width
+                 parameter DIVOUTW = 8, // output divider width
+                 parameter PHASEW = 8,  // phase shift adjust width
+                 parameter CW = 1,      // control vector width
+                 parameter SW = 1       // status vector width
                  )
    (
     // supplies
-    inout                     vdda,    // analog supply
-    inout                     vdd,     // digital core supply
-    inout                     vddaux,  // aux core supply
-    inout                     vss,     // common ground
+    inout                    vdda,   // analog supply
+    inout                    vdd,    // digital core supply
+    inout                    vddaux, // aux core supply
+    inout                    vss,    // common ground
     // clocks
-    input [NIN-1:0]           clkin,   // input reference clock
-    output [NOUT-1:0]         clkout,  // output clocks
+    input [NIN-1:0]          clkin,  // input reference clock
+    output [NOUT-1:0]        clkout, // output clocks
     // standard controls
-    input                     reset,   // active high async reset
-    input                     en,      // pll enable
-    input                     bypass,  // pll bypasses
-    input [NIN-1:0]           clksel,  // one hot clock selector
-    input [DIVINW-1:0]        divin,   // reference divider
-    input [DIVFBW-1:0]        divfb,   // feedback divider
-    input [NOUT*DIVPOSTW-1:0] divpost, // output divider
-    input [NOUT*PHASEW-1:0]   phase,   // output phase shift
-    output                    locked,  // pll is locked
+    input                    reset,  // active high async reset
+    input                    en,     // pll enable
+    input                    bypass, // pll bypasses
+    input [NIN-1:0]          clksel, // one hot clock selector
+    input [DIVINW-1:0]       divin,  // reference divider
+    input [DIVFBW-1:0]       divfb,  // feedback divider
+    input [NOUT*DIVOUTW-1:0] divout, // output divider
+    input [NOUT*PHASEW-1:0]  phase,  // output phase shift
+    output                   locked, // pll is locked
     // user defined signals (defined per unique PLL)
-    input [CW-1:0]            ctrl,    // controls
-    output [SW-1:0]           status   // status
+    input [CW-1:0]           ctrl,   // controls
+    output [SW-1:0]          status  // status
     );
 
    genvar i;


### PR DESCRIPTION
This feels pretty good, I think anyone who has ever instantiated a PLL should understand the intent here.

```verilog

la_pll #(.NIN(1),
            .NOUT(NPLLCLK),
            .DIVINW(DIVINW),
            .DIVFBW(DIVFBW),
            .DIVPOSTW(DIVPOSTW),
            .PHASEW(PHASEW),
            .CW(32),
            .SW(32))
   ipll (// Outputs
         .clkout   (pll_clkout[NPLLCLK-1:0]),
         .locked   (pll_locked),
         .status   (pll_status[SW-1:0]),
         // Inputs
         .clkin    (clkpin),
         .reset    (~nreset),
         .en       (pll_en),
         .bypass   (pll_bypass),
         .clksel   (1'b1),
         .divin    (pll_divin[DIVINW-1:0]),
         .divfb    (pll_divfb[DIVFBW-1:0]),
         .divpost  (pll_divpost[NPLLCLK*DIVPOSTW-1:0]),
         .phase    (pll_phase[NPLLCLK*PHASEW-1:0]),
         .ctrl     (pll_ctrl[CW-1:0]));

```