### PR TITLE
make cocotb loading optional

### DIFF
--- a/lambdalib/reusable_tests/auxlib/la_rsync/la_rsync_test.py
+++ b/lambdalib/reusable_tests/auxlib/la_rsync/la_rsync_test.py
@@ -1,62 +1,71 @@
-import cocotb
-from cocotb.clock import Clock
-from cocotb.triggers import Timer, RisingEdge, ReadOnly
+try:
+    import cocotb
+
+    from cocotb.clock import Clock
+    from cocotb.triggers import Timer, RisingEdge, ReadOnly
+    from lambdalib.reusable_tests.cocotb_common import run_cocotb
+    _has_cocotb = True
+except ModuleNotFoundError:
+    _has_cocotb = False
 
 from siliconcompiler import Sim, Project
 from lambdalib.auxlib import Rsync
 
-from lambdalib.reusable_tests.cocotb_common import run_cocotb
 
+if _has_cocotb:
+    @cocotb.test()
+    async def test_la_rsync_basic(dut):
+        """Test basic asynchronous assertion and synchronous de-assertion"""
 
-@cocotb.test()
-async def test_la_rsync_basic(dut):
-    """Test basic asynchronous assertion and synchronous de-assertion"""
+        clk_period_ns = 10
+        STAGES = int(dut.STAGES.value)
 
-    clk_period_ns = 10
-    STAGES = int(dut.STAGES.value)
+        nrst_in = dut.nrst_in
+        nrst_out = dut.nrst_out
 
-    nrst_in = dut.nrst_in
-    nrst_out = dut.nrst_out
+        # De-assert reset during start of test
+        nrst_in.value = 1
 
-    # De-assert reset during start of test
-    nrst_in.value = 1
+        # Start clock
+        Clock(dut.clk, clk_period_ns, unit="ns").start()
 
-    # Start clock
-    Clock(dut.clk, clk_period_ns, unit="ns").start()
+        ####################################
+        # 1. Trigger Asynchronous Reset
+        ####################################
+        await RisingEdge(dut.clk)
+        # Assert reset offset from clock edge
+        await Timer(clk_period_ns/2, unit="ns")
+        nrst_in.value = 0
 
-    ####################################
-    # 1. Trigger Asynchronous Reset
-    ####################################
-    await RisingEdge(dut.clk)
-    # Assert reset offset from clock edge
-    await Timer(clk_period_ns/2, unit="ns")
-    nrst_in.value = 0
+        # Check for immediate (asynchronous) assertion
+        await Timer(1, unit="step")
+        assert nrst_out.value == 0, "Reset output did not assert immediately!"
 
-    # Check for immediate (asynchronous) assertion
-    await Timer(1, unit="step")
-    assert nrst_out.value == 0, "Reset output did not assert immediately!"
+        ####################################
+        # 2. Trigger De-assertion
+        ####################################
+        await Timer(clk_period_ns*2, unit="ns")
+        nrst_in.value = 1
 
-    ####################################
-    # 2. Trigger De-assertion
-    ####################################
-    await Timer(clk_period_ns*2, unit="ns")
-    nrst_in.value = 1
+        # Wait for the synchronizer pipeline to clear.
+        cycle = 0
+        while True:
+            await ReadOnly()
+            # Check if it de-asserts too early
+            if cycle < STAGES:
+                assert nrst_out.value == 0, f"Reset de-asserted too early at cycle {cycle}"
+            else:
+                assert nrst_out.value == 1, f"Reset failed to de-assert {cycle}"
+                break
 
-    # Wait for the synchronizer pipeline to clear.
-    cycle = 0
-    while True:
-        await ReadOnly()
-        # Check if it de-asserts too early
-        if cycle < STAGES:
-            assert nrst_out.value == 0, f"Reset de-asserted too early at cycle {cycle}"
-        else:
-            assert nrst_out.value == 1, f"Reset failed to de-assert {cycle}"
-            break
+            await RisingEdge(dut.clk)
+            cycle += 1
 
         await RisingEdge(dut.clk)
-        cycle += 1
-
-    await RisingEdge(dut.clk)
+else:
+    def test_la_rsync_basic():
+        """Placeholder test when cocotb is not installed."""
+        pass
 
 
 def run_test(
@@ -65,6 +74,8 @@ def run_test(
     output_wave: bool,
     project: Project = None,
 ):
+    if not _has_cocotb:
+        raise RuntimeError("Cocotb is not installed; cannot run test.")
 
     if project is None:
         project = Sim(Rsync())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ test = [
     "cocotb == 2.0.1",
     "cocotb-bus == 0.3.0"
 ]
+cocotb = [
+    "cocotb == 2.0.1",
+    "cocotb-bus == 0.3.0"
+]
 
 lint = [
     "flake8 == 7.3.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tests now detect whether the optional cocotb dependency is available and adapt behavior accordingly.
  * When cocotb is absent, a safe placeholder test is provided and test execution is prevented with a clear runtime error.

* **Chores**
  * Added an optional cocotb dependency group to project configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->