### PR TITLE
Updating ramlib with a better interface

### DIFF
--- a/lambdalib/__init__.py
+++ b/lambdalib/__init__.py
@@ -13,7 +13,7 @@ from lambdalib import stdlib
 from lambdalib import ramlib
 from lambdalib import veclib
 
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 
 
 class LambalibTechLibrary(Design):

--- a/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
+++ b/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
@@ -182,4 +182,7 @@ module la_asyncfifo #(parameter DW = 32,         // Memory width
    // Read port (FIFO output)
    assign rd_dout[DW-1:0] = ram[rd_binptr_mem[AW-1:0]];
 
+   // Status (active in hard macro, tied off in soft model)
+   assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
+++ b/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
@@ -20,36 +20,31 @@
  *
  ****************************************************************************/
 
-module la_asyncfifo #(
-    parameter DW                = 32,       // Memory width
-    parameter DEPTH             = 4,        // FIFO depth
-    parameter ALMOSTFULL        = 0,        // FIFO depth
-    parameter NS                = 1,        // Number of power supplies
-    parameter CTRLW             = 1,        // width of asic ctrl interface
-    parameter TESTW             = 1,        // width of asic teset interface
-    parameter CHAOS             = 0,        // generates random full logic when set
-    parameter PROP              = "DEFAULT" // Pass through variable for hard macro
-) (  // write port
-    input                  wr_clk,
-    input                  wr_nreset,
-    input      [   DW-1:0] wr_din,         // data to write
-    input                  wr_en,          // write fifo
-    input                  wr_chaosmode,   // randomly assert fifo full when set
-    output reg             wr_full,        // fifo full
-    output reg             wr_almost_full, // fifo almost full
+module la_asyncfifo #(parameter DW = 32,         // Memory width
+                      parameter DEPTH = 4,       // FIFO depth
+                      parameter ALMOSTFULL = 0,  // FIFO depth
+                      parameter CTRLW = 32,      // width of ctrl interface
+                      parameter STATUSW = 32,    // width of status interface
+                      parameter PROP = "DEFAULT" // variable for hard macro
+                      )
+   (// write port
+    input               wr_clk,
+    input               wr_nreset,
+    input [ DW-1:0]     wr_din,         // data to write
+    input               wr_en,          // write fifo
+    output reg          wr_full,        // fifo full
+    output reg          wr_almost_full, // fifo almost full
     // read port
-    input                  rd_clk,
-    input                  rd_nreset,
-    output     [   DW-1:0] rd_dout,        // output data (next cycle)
-    input                  rd_en,          // read fifo
-    output reg             rd_empty,       // fifo is empty
-    // Power signals
-    input                  vss,            // ground signal
-    input      [   NS-1:0] vdd,            // supplies
-    // Generic interfaces
-    input      [CTRLW-1:0] ctrl,           // pass through ASIC control interface
-    input      [TESTW-1:0] test            // pass through ASIC test interface
-);
+    input               rd_clk,
+    input               rd_nreset,
+    output [ DW-1:0]    rd_dout,        // output data (next cycle)
+    input               rd_en,          // read fifo
+    output reg          rd_empty,       // fifo is empty
+    // Technology interfaces
+    input               selctrl,        // selects control interface
+    input [CTRLW-1:0]   ctrl,           // pass through control interface
+    input [STATUSW-1:0] status          // pass through status interface
+    );
 
     // local params
     localparam AW = (DEPTH == 1) ? 1 : $clog2(DEPTH);
@@ -63,7 +58,6 @@ module la_asyncfifo #(
     wire [AW:0] wr_binptr_nxt;
     wire [AW:0] wr_binptr_mem_nxt;
     wire [AW:0] wr_grayptr_sync;
-    wire        wr_chaosfull;
     wire        wr_almost_full_next;
 
     reg  [AW:0] rd_grayptr;
@@ -117,8 +111,7 @@ module la_asyncfifo #(
     always @(posedge wr_clk or negedge wr_nreset)
         if (~wr_nreset) wr_full <= 1'b0;
         else
-            wr_full <= (wr_chaosfull & wr_chaosmode) |
-                  (fifo_used + {{AW{1'b0}}, (wr_en && ~wr_full)}) == DEPTH[AW:0];
+            wr_full <= (fifo_used + {{AW{1'b0}}, (wr_en && ~wr_full)}) == DEPTH[AW:0];
 
     generate
       if (DEPTH == 1)
@@ -179,31 +172,14 @@ module la_asyncfifo #(
     //# Dual Port Memory
     //###########################
 
-    reg [DW-1:0] ram[DEPTH-1:0];
+   reg [DW-1:0] ram[DEPTH-1:0];
 
-    // Write port (FIFO input)
-    always @(posedge wr_clk) if (wr_en & ~wr_full) ram[wr_binptr_mem[AW-1:0]] <= wr_din[DW-1:0];
+   // Write port (FIFO input)
+   always @(posedge wr_clk)
+     if (wr_en & ~wr_full)
+       ram[wr_binptr_mem[AW-1:0]] <= wr_din[DW-1:0];
 
-    // Read port (FIFO output)
-    assign rd_dout[DW-1:0] = ram[rd_binptr_mem[AW-1:0]];
-
-    //############################
-    // Randomly Asserts FIFO full
-    //############################
-
-    generate
-        if (CHAOS) begin
-            // TODO: implement LFSR
-            reg chaosreg;
-            always @(posedge wr_clk or negedge wr_nreset)
-                if (~wr_nreset) chaosreg <= 1'b0;
-                else chaosreg <= ~chaosreg;
-            assign wr_chaosfull = chaosreg;
-        end else begin
-            assign wr_chaosfull = 1'b0;
-        end
-
-    endgenerate
-
+   // Read port (FIFO output)
+   assign rd_dout[DW-1:0] = ram[rd_binptr_mem[AW-1:0]];
 
 endmodule

--- a/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
+++ b/lambdalib/ramlib/la_asyncfifo/rtl/la_asyncfifo.v
@@ -43,7 +43,7 @@ module la_asyncfifo #(parameter DW = 32,         // Memory width
     // Technology interfaces
     input               selctrl,        // selects control interface
     input [CTRLW-1:0]   ctrl,           // pass through control interface
-    input [STATUSW-1:0] status          // pass through status interface
+    output [STATUSW-1:0] status          // pass through status interface
     );
 
     // local params

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
@@ -15,63 +15,61 @@
  *
  * Technology specific implementations of "la_dpram" would generally include
  * one or more hardcoded instantiations of RAM modules with a generate
- * statement relying on the "PROP" to select between the list of modules
- * at build time.
+ * statement relying on the "PROP", AW, and DW to select between the list of
+ * modules at build time.
+ *
+ * The 'selctrl' signal tells the implementation to select the ctrl interface
+ * if set to one, otherwise hard coded tech specific parameters inside the
+ * lambdalib implementations are used to control the RAM.
  *
  ****************************************************************************/
 
-module la_dpram #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // address width (derived)
-    parameter PROP  = "DEFAULT",  // pass through variable for hard macro
-    parameter CTRLW = 128,        // width of asic ctrl interface
-    parameter TESTW = 128         // width of asic test interface
-) (  // Write port
-    input             wr_clk,   // write clock
-    input             wr_ce,    // write chip-enable
-    input             wr_we,    // write enable
-    input [DW-1:0]    wr_wmask, // write mask
-    input [AW-1:0]    wr_addr,  // write address
-    input [DW-1:0]    wr_din,   //write data in
+module la_dpram #(parameter DW = 32,          // Memory width
+                  parameter AW = 10,          // address width (derived)
+                  parameter PROP = "DEFAULT", // hard macro property
+                  parameter CTRLW = 32,       // width of ctrl interface
+                  parameter STATUSW = 32      // width of status interface
+                  )
+   (// Write port
+    input               wr_clk,   // write clock
+    input               wr_ce,    // write chip-enable
+    input               wr_we,    // write enable
+    input [DW-1:0]      wr_wmask, // write mask
+    input [AW-1:0]      wr_addr,  // write address
+    input [DW-1:0]      wr_din,   //write data in
     // Read port
-    input             rd_clk,   // read clock
-    input             rd_ce,    // read chip-enable
-    input [AW-1:0]    rd_addr,  // read address
-    output [DW-1:0]   rd_dout,  //read data out
-    // Power signal
-    input             vss,      // ground signal
-    input             vdd,      // memory core array power
-    input             vddio,    // periphery/io power
+    input               rd_clk,   // read clock
+    input               rd_ce,    // read chip-enable
+    input [AW-1:0]      rd_addr,  // read address
+    output [DW-1:0]     rd_dout,  //read data out
     // Generic interfaces
-    input [CTRLW-1:0] ctrl,     // pass through ASIC control interface
-    input [TESTW-1:0] test      // pass through ASIC test interface
-);
-
-    la_dpram_impl #(
-        .DW         (DW),
-        .AW         (AW),
-        .PROP       (PROP),
-        .CTRLW      (CTRLW),
-        .TESTW      (TESTW)
-    ) memory (
-        .wr_clk     (wr_clk),
-        .wr_ce      (wr_ce),
-        .wr_we      (wr_we),
-        .wr_wmask   (wr_wmask),
-        .wr_addr    (wr_addr),
-        .wr_din     (wr_din),
-
-        .rd_clk     (rd_clk),
-        .rd_ce      (rd_ce),
-        .rd_addr    (rd_addr),
-        .rd_dout    (rd_dout),
-
-        .vss        (vss),
-        .vdd        (vdd),
-        .vddio      (vddio),
-
-        .ctrl       (ctrl),
-        .test       (test)
+    input               selctrl,  // selects control interface
+    input [CTRLW-1:0]   ctrl,     // pass through control interface
+    input [STATUSW-1:0] status    // pass through status interface
     );
+
+   la_dpram_impl #(.DW      (DW),
+                   .AW      (AW),
+                   .PROP    (PROP),
+                   .CTRLW   (CTRLW),
+                   .STATUSW (STATUSW)
+                   )
+   memory (// write port
+           .wr_clk     (wr_clk),
+           .wr_ce      (wr_ce),
+           .wr_we      (wr_we),
+           .wr_wmask   (wr_wmask),
+           .wr_addr    (wr_addr),
+           .wr_din     (wr_din),
+           // read port
+           .rd_clk     (rd_clk),
+           .rd_ce      (rd_ce),
+           .rd_addr    (rd_addr),
+           .rd_dout    (rd_dout),
+           // ctrl
+           .selctrl    (selctrl),
+           .ctrl       (ctrl),
+           .status     (status));
+
 
 endmodule

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
@@ -45,7 +45,7 @@ module la_dpram #(parameter DW = 32,          // Memory width
     // Generic interfaces
     input               selctrl,  // selects control interface
     input [CTRLW-1:0]   ctrl,     // pass through control interface
-    input [STATUSW-1:0] status    // pass through status interface
+    output [STATUSW-1:0] status    // pass through status interface
     );
 
    la_dpram_impl #(.DW      (DW),

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -57,4 +57,7 @@ module la_dpram_impl #(
    // Read Port
    always @(posedge rd_clk) if (rd_ce) rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
 
+   // Status (active in hard macro, tied off in soft model)
+   assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -42,7 +42,7 @@ module la_dpram_impl #(
     // Technology interfaces
     input               selctrl,  // selects control interface
     input [CTRLW-1:0]   ctrl,     // pass through control interface
-    input [STATUSW-1:0] status    // pass through status interface
+    output [STATUSW-1:0] status    // pass through status interface
     );
 
    // Generic RTL RAM

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -21,42 +21,40 @@
  ****************************************************************************/
 
 module la_dpram_impl #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // address width (derived)
-    parameter PROP  = "DEFAULT",  // pass through variable for hard macro
-    parameter CTRLW = 128,        // width of asic ctrl interface
-    parameter TESTW = 128         // width of asic test interface
-) (  // Write port
-    input wr_clk,  // write clock
-    input wr_ce,  // write chip-enable
-    input wr_we,  // write enable
-    input [DW-1:0] wr_wmask,  // write mask
-    input [AW-1:0] wr_addr,  // write address
-    input [DW-1:0] wr_din,  //write data in
+                       parameter DW = 32,          // memory width
+                       parameter AW = 10,          // address width (derived)
+                       parameter PROP = "DEFAULT", // variable for hard macro
+                       parameter CTRLW = 32,       // width of ctrl interface
+                       parameter STATUSW = 32      // width of status interface
+                       )
+   (// Write port
+    input               wr_clk,   // write clock
+    input               wr_ce,    // write chip-enable
+    input               wr_we,    // write enable
+    input [DW-1:0]      wr_wmask, // write mask
+    input [AW-1:0]      wr_addr,  // write address
+    input [DW-1:0]      wr_din,   //write data in
     // Read port
-    input rd_clk,  // read clock
-    input rd_ce,  // read chip-enable
-    input [AW-1:0] rd_addr,  // read address
+    input               rd_clk,   // read clock
+    input               rd_ce,    // read chip-enable
+    input [AW-1:0]      rd_addr,  // read address
     output reg [DW-1:0] rd_dout,  //read data out
-    // Power signal
-    input vss,  // ground signal
-    input vdd,  // memory core array power
-    input vddio,  // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl,  // pass through ASIC control interface
-    input [TESTW-1:0] test  // pass through ASIC test interface
-);
+    // Technology interfaces
+    input               selctrl,  // selects control interface
+    input [CTRLW-1:0]   ctrl,     // pass through control interface
+    input [STATUSW-1:0] status    // pass through status interface
+    );
 
-    // Generic RTL RAM
-    reg     [DW-1:0] ram[(2**AW)-1:0];
-    integer          i;
+   // Generic RTL RAM
+   reg     [DW-1:0] ram[(2**AW)-1:0];
+   integer          i;
 
-    // Write port
-    always @(posedge wr_clk)
-        for (i = 0; i < DW; i = i + 1)
-            if (wr_ce & wr_we & wr_wmask[i]) ram[wr_addr[AW-1:0]][i] <= wr_din[i];
+   // Write port
+   always @(posedge wr_clk)
+     for (i = 0; i < DW; i = i + 1)
+       if (wr_ce & wr_we & wr_wmask[i]) ram[wr_addr[AW-1:0]][i] <= wr_din[i];
 
-    // Read Port
-    always @(posedge rd_clk) if (rd_ce) rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
+   // Read Port
+   always @(posedge rd_clk) if (rd_ce) rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
 
 endmodule

--- a/lambdalib/ramlib/la_spram/rtl/la_spram.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram.v
@@ -15,55 +15,51 @@
  *
  * Technology specific implementations of "la_spram" would generally include
  * one or more hardcoded instantiations of RAM modules with a generate
- * statement relying on the "PROP" to select between the list of modules
- * at build time.
+ * statement relying on the "PROP", AW, and DW to select between the list of
+ * modules at build time.
+ *
+ * The 'selctrl' signal tells the implementation to select the ctrl interface
+ * if set to one, otherwise hard coded tech specific parameters inside the
+ * lambdalib implementations are used to control the RAM.
  *
  ****************************************************************************/
 
-module la_spram #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // Address width (derived)
-    parameter PROP  = "DEFAULT",  // Pass through variable for hard macro
-    parameter CTRLW = 1,          // Width of asic ctrl interface
-    parameter TESTW = 1           // Width of asic test interface
-) (  // Memory interface
-    input             clk,   // write clock
-    input             ce,    // chip enable
-    input             we,    // write enable
-    input [DW-1:0]    wmask, //per bit write mask
-    input [AW-1:0]    addr,  //write address
-    input [DW-1:0]    din,   //write data
-    output [DW-1:0]   dout,  //read output data
-    // Power signals
-    input             vss,   // ground signal
-    input             vdd,   // memory core array power
-    input             vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl,  // pass through ASIC control interface
-    input [TESTW-1:0] test   // pass through ASIC test interface
-);
-
-    la_spram_impl #(
-        .DW     (DW),
-        .AW     (AW),
-        .PROP   (PROP),
-        .CTRLW  (CTRLW),
-        .TESTW  (TESTW)
-    ) memory (
-        .clk    (clk),
-        .ce     (ce),
-        .we     (we),
-        .wmask  (wmask),
-        .addr   (addr),
-        .din    (din),
-        .dout   (dout),
-
-        .vss    (vss),
-        .vdd    (vdd),
-        .vddio  (vddio),
-
-        .ctrl   (ctrl),
-        .test   (test)
+module la_spram #(parameter DW = 32,          // Memory width
+                  parameter AW = 10,          // Address width (derived)
+                  parameter PROP = "DEFAULT", // variable for hard macro
+                  parameter CTRLW = 32,       // width of ctrl interface
+                  parameter STATUSW = 32      // width of status interface
+                  )
+   (// Memory interface
+    input               clk,     // write clock
+    input               ce,      // chip enable
+    input               we,      // write enable
+    input [DW-1:0]      wmask,   //per bit write mask
+    input [AW-1:0]      addr,    //write address
+    input [DW-1:0]      din,     //write data
+    output [DW-1:0]     dout,    //read output data
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
     );
+
+   la_spram_impl #(.DW      (DW),
+                   .AW      (AW),
+                   .PROP    (PROP),
+                   .CTRLW   (CTRLW),
+                   .STATUSW (STATUSW))
+   memory (// port
+           .clk    (clk),
+           .ce     (ce),
+           .we     (we),
+           .wmask  (wmask),
+           .addr   (addr),
+           .din    (din),
+           .dout   (dout),
+           // macro interface
+           .selctrl    (selctrl),
+           .ctrl       (ctrl),
+           .status     (status));
 
 endmodule

--- a/lambdalib/ramlib/la_spram/rtl/la_spram.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram.v
@@ -41,7 +41,7 @@ module la_spram #(parameter DW = 32,          // Memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
    la_spram_impl #(.DW      (DW),

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -60,4 +60,7 @@ module la_spram_impl #(parameter DW = 32,          // memory width
       if (ce)
         dout[DW-1:0] <= ram[addr[AW-1:0]];
 
+    // Status (active in hard macro, tied off in soft model)
+    assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -37,7 +37,7 @@ module la_spram_impl #(parameter DW = 32,          // memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
     // Generic RTL RAM

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -20,29 +20,24 @@
  *
  ****************************************************************************/
 
-module la_spram_impl
-  #(
-    parameter DW = 32,          // Memory width
-    parameter AW = 10,          // Address width (derived)
-    parameter PROP = "DEFAULT", // Pass through variable for hard macro
-    parameter CTRLW = 1,        // Width of asic ctrl interface
-    parameter TESTW = 1         // Width of asic test interface
-    )
+module la_spram_impl #(parameter DW = 32,          // memory width
+                       parameter AW = 10,          // address width (derived)
+                       parameter PROP = "DEFAULT", // variable for hard macro
+                       parameter CTRLW = 32,       // width of ctrl interface
+                       parameter STATUSW = 32      // width of status interface
+                       )
    (// Memory interface
-    input               clk,   // write clock
-    input               ce,    // chip enable
-    input               we,    // write enable
-    input [DW-1:0]      wmask, //per bit write mask
-    input [AW-1:0]      addr,  //write address
-    input [DW-1:0]      din,   //write data
-    output reg [DW-1:0] dout,  //read output data
-    // Power signals
-    input               vss,   // ground signal
-    input               vdd,   // memory core array power
-    input               vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0]   ctrl,  // pass through ASIC control interface
-    input [TESTW-1:0]   test   // pass through ASIC test interface
+    input               clk,     // write clock
+    input               ce,      // chip enable
+    input               we,      // write enable
+    input [DW-1:0]      wmask,   //per bit write mask
+    input [AW-1:0]      addr,    //write address
+    input [DW-1:0]      din,     //write data
+    output reg [DW-1:0] dout,    //read output data
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
     );
 
     // Generic RTL RAM

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
@@ -20,50 +20,42 @@
  *
  ****************************************************************************/
 
-module la_spregfile #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // Address width (derived)
-    parameter PROP  = "DEFAULT",  // Pass through variable for hard macro
-    parameter CTRLW = 1,          // Width of asic ctrl interface
-    parameter TESTW = 1           // Width of asic test interface
-) (  // Memory interface
-    input             clk,   // write clock
-    input             ce,    // chip enable
-    input             we,    // write enable
-    input [DW-1:0]    wmask, //per bit write mask
-    input [AW-1:0]    addr,  //write address
-    input [DW-1:0]    din,   //write data
-    output [DW-1:0]   dout,  //read output data
-    // Power signals
-    input             vss,   // ground signal
-    input             vdd,   // memory core array power
-    input             vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl,  // pass through ASIC control interface
-    input [TESTW-1:0] test   // pass through ASIC test interface
-);
-
-    la_spregfile_impl #(
-        .DW     (DW),
-        .AW     (AW),
-        .PROP   (PROP),
-        .CTRLW  (CTRLW),
-        .TESTW  (TESTW)
-    ) memory (
-        .clk    (clk),
-        .ce     (ce),
-        .we     (we),
-        .wmask  (wmask),
-        .addr   (addr),
-        .din    (din),
-        .dout   (dout),
-
-        .vss    (vss),
-        .vdd    (vdd),
-        .vddio  (vddio),
-
-        .ctrl   (ctrl),
-        .test   (test)
+module la_spregfile #(parameter DW = 32,          // Memory width
+                      parameter AW = 10,          // Address width (derived)
+                      parameter PROP = "DEFAULT", // variable for hard macro
+                      parameter CTRLW = 32,       // width of ctrl interface
+                      parameter STATUSW = 32      // width of status interface
+                      )
+   (// Memory interface
+    input               clk,     // write clock
+    input               ce,      // chip enable
+    input               we,      // write enable
+    input [DW-1:0]      wmask,   // per bit write mask
+    input [AW-1:0]      addr,    // write address
+    input [DW-1:0]      din,     // write data
+    output [DW-1:0]     dout,    // read output data
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
     );
+
+   la_spregfile_impl #(.DW      (DW),
+                       .AW      (AW),
+                       .PROP    (PROP),
+                       .CTRLW   (CTRLW),
+                       .STATUSW (STATUSW))
+   memory (
+           .clk    (clk),
+           .ce     (ce),
+           .we     (we),
+           .wmask  (wmask),
+           .addr   (addr),
+           .din    (din),
+           .dout   (dout),
+            // macro interface
+           .selctrl    (selctrl),
+           .ctrl       (ctrl),
+           .status     (status));
 
 endmodule

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
@@ -37,7 +37,7 @@ module la_spregfile #(parameter DW = 32,          // Memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
    la_spregfile_impl #(.DW      (DW),

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
@@ -37,7 +37,7 @@ module la_spregfile_impl #(parameter DW = 32,          // Memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
     // Generic RTL RAM

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
@@ -20,29 +20,24 @@
  *
  ****************************************************************************/
 
-module la_spregfile_impl
-  #(
-    parameter DW = 32,          // Memory width
-    parameter AW = 10,          // Address width (derived)
-    parameter PROP = "DEFAULT", // Pass through variable for hard macro
-    parameter CTRLW = 1,        // Width of asic ctrl interface
-    parameter TESTW = 1         // Width of asic test interface
-    )
+module la_spregfile_impl #(parameter DW = 32,          // Memory width
+                           parameter AW = 10,          // Address width (derived)
+                           parameter PROP = "DEFAULT", // variable for hard macro
+                           parameter CTRLW = 32,       // width of ctrl interface
+                           parameter STATUSW = 32      // width of status interface
+                           )
    (// Memory interface
-    input               clk,   // write clock
-    input               ce,    // chip enable
-    input               we,    // write enable
-    input [DW-1:0]      wmask, //per bit write mask
-    input [AW-1:0]      addr,  //write address
-    input [DW-1:0]      din,   //write data
-    output reg [DW-1:0] dout,  //read output data
-    // Power signals
-    input               vss,   // ground signal
-    input               vdd,   // memory core array power
-    input               vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0]   ctrl,  // pass through ASIC control interface
-    input [TESTW-1:0]   test   // pass through ASIC test interface
+    input               clk,     // write clock
+    input               ce,      // chip enable
+    input               we,      // write enable
+    input [DW-1:0]      wmask,   // per bit write mask
+    input [AW-1:0]      addr,    // write address
+    input [DW-1:0]      din,     // write data
+    output reg [DW-1:0] dout,    // read output data
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
     );
 
     // Generic RTL RAM

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
@@ -60,4 +60,7 @@ module la_spregfile_impl #(parameter DW = 32,          // Memory width
       if (ce)
         dout[DW-1:0] <= ram[addr[AW-1:0]];
 
+    // Status (active in hard macro, tied off in soft model)
+    assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
+++ b/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
@@ -101,4 +101,7 @@ module la_syncfifo #(parameter DW = 32,         // Memory width
     // Read port (FIFO output)
     assign rd_dout[DW-1:0] = ram[rd_addr[AW-1:0]];
 
+    // Status (active in hard macro, tied off in soft model)
+    assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
+++ b/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
@@ -30,7 +30,7 @@ module la_syncfifo #(parameter DW = 32,         // Memory width
     // Technology interfaces
     input               selctrl,  // selects control interface
     input [CTRLW-1:0]   ctrl,     // pass through control interface
-    input [STATUSW-1:0] status    // pass through status interface
+    output [STATUSW-1:0] status    // pass through status interface
     );
 
     // local params

--- a/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
+++ b/lambdalib/ramlib/la_syncfifo/rtl/la_syncfifo.v
@@ -9,34 +9,29 @@
  *
  ****************************************************************************/
 
-module la_syncfifo
-  #(
-    parameter DW    = 32,        // Memory width
-    parameter DEPTH = 4,         // FIFO depth
-    parameter NS    = 1,         // Number of power supplies
-    parameter CHAOS = 1,         // generates random full logic when set
-    parameter CTRLW = 1,         // width of asic ctrl interface
-    parameter TESTW = 1,         // width of asic test interface
-    parameter PROP  = "DEFAULT"  // Pass through variable for hard macro
-    )
+module la_syncfifo #(parameter DW = 32,         // Memory width
+                     parameter DEPTH = 4,       // FIFO depth
+                     parameter CTRLW = 32,      // width of ctrl interface
+                     parameter STATUSW = 32,    // width of status interface
+                     parameter PROP = "DEFAULT" // variable for hard macro
+                     )
    (// basic interface
-    input             clk,
-    input             nreset,//async reset
-    input             clear, //clear fifo statemachine (sync)
-    input             vss, // ground signal
-    input [NS-1:0]    vdd, // supplies
-    input             chaosmode, // randomly assert fifo full when set
-    input [CTRLW-1:0] ctrl, // pass through ASIC control interface
-    input [TESTW-1:0] test, // pass through ASIC test interface
+    input               clk,
+    input               nreset,   //async reset
+    input               clear,    //clear fifo statemachine (sync)
     // write port
-    input             wr_en, // write fifo
-    input [DW-1:0]    wr_din, // data to write
-    output            wr_full, // fifo full
+    input               wr_en,    // write fifo
+    input [DW-1:0]      wr_din,   // data to write
+    output              wr_full,  // fifo full
     // read port
-    input             rd_en, // read fifo
-    output [DW-1:0]   rd_dout, // output data
-    output            rd_empty    // fifo is empty
-);
+    input               rd_en,    // read fifo
+    output [DW-1:0]     rd_dout,  // output data
+    output              rd_empty, // fifo is empty
+    // Technology interfaces
+    input               selctrl,  // selects control interface
+    input [CTRLW-1:0]   ctrl,     // pass through control interface
+    input [STATUSW-1:0] status    // pass through status interface
+    );
 
     // local params
     parameter AW = $clog2(DEPTH);
@@ -48,7 +43,6 @@ module la_syncfifo
     wire [AW:0] rd_addr_nxt;
     wire        fifo_read;
     wire        fifo_write;
-    wire        chaosfull;
     wire        rd_wrap_around;
     wire        wr_wrap_around;
 
@@ -57,10 +51,7 @@ module la_syncfifo
     //############################
 
     // support any fifo depth
-    assign wr_full = (chaosfull & chaosmode) |
-                     {~wr_addr[AW], wr_addr[AW-1:0]} == rd_addr[AW:0];
-
-
+    assign wr_full = {~wr_addr[AW], wr_addr[AW-1:0]} == rd_addr[AW:0];
 
     assign rd_empty = wr_addr[AW:0] == rd_addr[AW:0];
 
@@ -109,23 +100,5 @@ module la_syncfifo
 
     // Read port (FIFO output)
     assign rd_dout[DW-1:0] = ram[rd_addr[AW-1:0]];
-
-
-    //############################
-    // Randomly Asserts FIFO full
-    //############################
-
-    generate
-        if (CHAOS) begin
-            // TODO: implement LFSR
-            reg chaosreg;
-            always @(posedge clk or negedge nreset)
-                if (~nreset) chaosreg <= 1'b0;
-                else chaosreg <= ~chaosreg;
-            assign chaosfull = chaosreg;
-        end else begin
-            assign chaosfull = 1'b0;
-        end
-    endgenerate
 
 endmodule

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
@@ -45,7 +45,7 @@ module la_tdpram #(parameter DW = 32,          // Memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
    la_tdpram_impl #(.DW      (DW),

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
@@ -20,66 +20,58 @@
  *
  ****************************************************************************/
 
-module la_tdpram #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // address width (derived)
-    parameter PROP  = "DEFAULT",  // pass through variable for hard macro
-    parameter CTRLW = 128,        // width of asic ctrl interface
-    parameter TESTW = 128         // width of asic test interface
-) (  // A port
-    input             clk_a,      // write clock
-    input             ce_a,       // write chip-enable
-    input             we_a,       // write enable
-    input [DW-1:0]    wmask_a,    // write mask
-    input [AW-1:0]    addr_a,     // write address
-    input [DW-1:0]    din_a,      // write data in
-    output [DW-1:0]   dout_a,     // read data out
+module la_tdpram #(parameter DW = 32,          // Memory width
+                   parameter AW = 10,          // Address width (derived)
+                   parameter PROP = "DEFAULT", // variable for hard macro
+                   parameter CTRLW = 32,       // width of ctrl interface
+                   parameter STATUSW = 32      // width of status interface
+                   )
+   (// A port
+    input               clk_a,   // write clock
+    input               ce_a,    // write chip-enable
+    input               we_a,    // write enable
+    input [DW-1:0]      wmask_a, // write mask
+    input [AW-1:0]      addr_a,  // write address
+    input [DW-1:0]      din_a,   // write data in
+    output [DW-1:0]     dout_a,  // read data out
     // B port
-    input             clk_b,      // write clock
-    input             ce_b,       // write chip-enable
-    input             we_b,       // write enable
-    input [DW-1:0]    wmask_b,    // write mask
-    input [AW-1:0]    addr_b,     // write address
-    input [DW-1:0]    din_b,      // write data in
-    output [DW-1:0]   dout_b,     // read data out
-    // Power signal
-    input             vss,        // ground signal
-    input             vdd,        // memory core array power
-    input             vddio,      // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl,       // pass through ASIC control interface
-    input [TESTW-1:0] test        // pass through ASIC test interface
-);
-
-    la_tdpram_impl #(
-        .DW         (DW),
-        .AW         (AW),
-        .PROP       (PROP),
-        .CTRLW      (CTRLW),
-        .TESTW      (TESTW)
-    ) memory (
-        .clk_a      (clk_a),
-        .ce_a       (ce_a),
-        .we_a       (we_a),
-        .wmask_a    (wmask_a),
-        .addr_a     (addr_a),
-        .din_a      (din_a),
-        .dout_a     (dout_a),
-
-        .clk_b      (clk_b),
-        .ce_b       (ce_b),
-        .we_b       (we_b),
-        .wmask_b    (wmask_b),
-        .addr_b     (addr_b),
-        .din_b      (din_b),
-        .dout_b     (dout_b),
-
-        .vss        (vss),
-        .vdd        (vdd),
-        .vddio      (vddio),
-
-        .ctrl       (ctrl),
-        .test       (test)
+    input               clk_b,   // write clock
+    input               ce_b,    // write chip-enable
+    input               we_b,    // write enable
+    input [DW-1:0]      wmask_b, // write mask
+    input [AW-1:0]      addr_b,  // write address
+    input [DW-1:0]      din_b,   // write data in
+    output [DW-1:0]     dout_b,  // read data out
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
     );
+
+   la_tdpram_impl #(.DW      (DW),
+                    .AW      (AW),
+                    .PROP    (PROP),
+                    .CTRLW   (CTRLW),
+                    .STATUSW (STATUSW))
+   memory (// a port
+           .clk_a      (clk_a),
+           .ce_a       (ce_a),
+           .we_a       (we_a),
+           .wmask_a    (wmask_a),
+           .addr_a     (addr_a),
+           .din_a      (din_a),
+           .dout_a     (dout_a),
+           // b port
+           .clk_b      (clk_b),
+           .ce_b       (ce_b),
+           .we_b       (we_b),
+           .wmask_b    (wmask_b),
+           .addr_b     (addr_b),
+           .din_b      (din_b),
+           .dout_b     (dout_b),
+            // macro interface
+           .selctrl    (selctrl),
+           .ctrl       (ctrl),
+           .status     (status));
 
 endmodule

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -20,36 +20,33 @@
  *
  ****************************************************************************/
 
-module la_tdpram_impl #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // address width (derived)
-    parameter PROP  = "DEFAULT",  // pass through variable for hard macro
-    parameter CTRLW = 128,        // width of asic ctrl interface
-    parameter TESTW = 128         // width of asic test interface
-) (  // Write port
-    input               clk_a,    // write clock
-    input               ce_a,     // write chip-enable
-    input               we_a,     // write enable
-    input [DW-1:0]      wmask_a,  // write mask
-    input [AW-1:0]      addr_a,   // write address
-    input [DW-1:0]      din_a,    // write data in
-    output reg [DW-1:0] dout_a,   // read data out
+module la_tdpram_impl #(parameter DW = 32,          // Memory width
+                        parameter AW = 10,          // Address width (derived)
+                        parameter PROP = "DEFAULT", // variable for hard macro
+                        parameter CTRLW = 32,       // width of ctrl interface
+                        parameter STATUSW = 32      // width of status interface
+                        )
+   (// A port
+    input               clk_a,   // write clock
+    input               ce_a,    // write chip-enable
+    input               we_a,    // write enable
+    input [DW-1:0]      wmask_a, // write mask
+    input [AW-1:0]      addr_a,  // write address
+    input [DW-1:0]      din_a,   // write data in
+    output reg [DW-1:0] dout_a,  // read data out
     // B port
-    input               clk_b,    // write clock
-    input               ce_b,     // write chip-enable
-    input               we_b,     // write enable
-    input [DW-1:0]      wmask_b,  // write mask
-    input [AW-1:0]      addr_b,   // write address
-    input [DW-1:0]      din_b,    // write data in
-    output reg [DW-1:0] dout_b,   // read data out
-    // Power signal
-    input               vss,      // ground signal
-    input               vdd,      // memory core array power
-    input               vddio,    // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0]   ctrl,     // pass through ASIC control interface
-    input [TESTW-1:0]   test      // pass through ASIC test interface
-);
+    input               clk_b,   // write clock
+    input               ce_b,    // write chip-enable
+    input               we_b,    // write enable
+    input [DW-1:0]      wmask_b, // write mask
+    input [AW-1:0]      addr_b,  // write address
+    input [DW-1:0]      din_b,   // write data in
+    output reg [DW-1:0] dout_b,  // read data out
+    // Technology interfaces
+    input               selctrl, // selects control interface
+    input [CTRLW-1:0]   ctrl,    // pass through control interface
+    input [STATUSW-1:0] status   // pass through status interface
+    );
 
     // Generic RTL RAM
    /* verilator lint_off MULTIDRIVEN */

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -87,4 +87,7 @@ module la_tdpram_impl #(parameter DW = 32,          // Memory width
       end
    end
 
+   // Status (active in hard macro, tied off in soft model)
+   assign status = {STATUSW{1'b0}};
+
 endmodule

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -45,7 +45,7 @@ module la_tdpram_impl #(parameter DW = 32,          // Memory width
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
-    input [STATUSW-1:0] status   // pass through status interface
+    output [STATUSW-1:0] status   // pass through status interface
     );
 
     // Generic RTL RAM

--- a/lambdalib/ramlib/templates/la_dprammemory.v
+++ b/lambdalib/ramlib/templates/la_dprammemory.v
@@ -8,7 +8,7 @@
  * This is a wrapper for selecting from a set of hardened memory macros.
  *
  * A synthesizable reference model is used when the PROP is DEFAULT. The
- * synthesizable model does not implement the cfg and test interface and should
+ * synthesizable model does not implement the ctrl interface and should
  * only be used for basic testing and for synthesizing for FPGA devices.
  * Advanced ASIC development should rely on complete functional models
  * supplied on a per macro basis.
@@ -22,11 +22,11 @@
 
 (* keep_hierarchy *)
 module {{ type }}
-  #(parameter DW     = 32,          // Memory width
-    parameter AW     = 10,          // Address width (derived)
-    parameter PROP   = "DEFAULT",   // Pass through variable for hard macro
-    parameter CTRLW  = 128,         // Width of asic ctrl interface
-    parameter TESTW  = 128          // Width of asic test interface
+  #(parameter DW      = 32,         // Memory width
+    parameter AW      = 10,         // Address width (derived)
+    parameter PROP    = "DEFAULT",  // Pass through variable for hard macro
+    parameter CTRLW   = 32,         // Width of ctrl interface
+    parameter STATUSW = 32          // Width of status interface
     )
    (// Memory interface
     // Write port
@@ -41,13 +41,10 @@ module {{ type }}
     input rd_ce, // read chip-enable
     input [AW-1:0] rd_addr, // read address
     output [DW-1:0] rd_dout, //read data out
-    // Power signals
-    input vss, // ground signal
-    input vdd, // memory core array power
-    input vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl, // pass through ASIC control interface
-    input [TESTW-1:0] test // pass through ASIC test interface
+    // Technology interfaces
+    input selctrl, // selects control interface
+    input [CTRLW-1:0] ctrl, // pass through control interface
+    output [STATUSW-1:0] status // pass through status interface
     );
 
     // Total number of bits
@@ -60,7 +57,7 @@ module {{ type }}
     localparam MEM_WIDTH = {% for memory, width in width_table %}
       (MEM_PROP == "{{ memory }}") ? {{ width }} :{% endfor %}
       0;
- 
+
     localparam MEM_DEPTH = {% for memory, depth in depth_table %}
       (MEM_PROP == "{{ memory }}") ? {{ depth }} :{% endfor %}
       0;
@@ -72,7 +69,7 @@ module {{ type }}
             .AW(AW),
             .PROP(PROP),
             .CTRLW(CTRLW),
-            .TESTW(TESTW)
+            .STATUSW(STATUSW)
         ) memory(
             // Write port
             .wr_clk(wr_clk),
@@ -86,12 +83,10 @@ module {{ type }}
             .rd_ce(rd_ce),
             .rd_addr(rd_addr),
             .rd_dout(rd_dout),
-            // Power/control
-            .vss(vss),
-            .vdd(vdd),
-            .vddio(vddio),
+            // Technology interfaces
+            .selctrl(selctrl),
             .ctrl(ctrl),
-            .test(test)
+            .status(status)
         );
       end
       if (MEM_PROP != "SOFT") begin: itech

--- a/lambdalib/ramlib/templates/la_sprammemory.v
+++ b/lambdalib/ramlib/templates/la_sprammemory.v
@@ -8,7 +8,7 @@
  * This is a wrapper for selecting from a set of hardened memory macros.
  *
  * A synthesizable reference model is used when the PROP is DEFAULT. The
- * synthesizable model does not implement the cfg and test interface and should
+ * synthesizable model does not implement the ctrl interface and should
  * only be used for basic testing and for synthesizing for FPGA devices.
  * Advanced ASIC development should rely on complete functional models
  * supplied on a per macro basis.
@@ -22,11 +22,11 @@
 
 (* keep_hierarchy *)
 module {{ type }}
-  #(parameter DW     = 32,          // Memory width
-    parameter AW     = 10,          // Address width (derived)
-    parameter PROP   = "DEFAULT",   // Pass through variable for hard macro
-    parameter CTRLW  = 128,         // Width of asic ctrl interface
-    parameter TESTW  = 128          // Width of asic test interface
+  #(parameter DW      = 32,         // Memory width
+    parameter AW      = 10,         // Address width (derived)
+    parameter PROP    = "DEFAULT",  // Pass through variable for hard macro
+    parameter CTRLW   = 32,         // Width of ctrl interface
+    parameter STATUSW = 32          // Width of status interface
     )
    (// Memory interface
     input clk, // write clock
@@ -36,13 +36,10 @@ module {{ type }}
     input [AW-1:0] addr, //write address
     input [DW-1:0] din, //write data
     output [DW-1:0] dout, //read output data
-    // Power signals
-    input vss, // ground signal
-    input vdd, // memory core array power
-    input vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl, // pass through ASIC control interface
-    input [TESTW-1:0] test // pass through ASIC test interface
+    // Technology interfaces
+    input selctrl, // selects control interface
+    input [CTRLW-1:0] ctrl, // pass through control interface
+    output [STATUSW-1:0] status // pass through status interface
     );
 
     // Total number of bits
@@ -55,7 +52,7 @@ module {{ type }}
     localparam MEM_WIDTH = {% for memory, width in width_table %}
       (MEM_PROP == "{{ memory }}") ? {{ width }} :{% endfor %}
       0;
- 
+
     localparam MEM_DEPTH = {% for memory, depth in depth_table %}
       (MEM_PROP == "{{ memory }}") ? {{ depth }} :{% endfor %}
       0;
@@ -67,7 +64,7 @@ module {{ type }}
             .AW(AW),
             .PROP(PROP),
             .CTRLW(CTRLW),
-            .TESTW(TESTW)
+            .STATUSW(STATUSW)
         ) memory(
             .clk(clk),
             .ce(ce),
@@ -76,11 +73,9 @@ module {{ type }}
             .addr(addr),
             .din(din),
             .dout(dout),
-            .vss(vss),
-            .vdd(vdd),
-            .vddio(vddio),
+            .selctrl(selctrl),
             .ctrl(ctrl),
-            .test(test)
+            .status(status)
         );
       end
       if (MEM_PROP != "SOFT") begin: itech

--- a/lambdalib/ramlib/templates/la_spregfilememory.v
+++ b/lambdalib/ramlib/templates/la_spregfilememory.v
@@ -8,7 +8,7 @@
  * This is a wrapper for selecting from a set of hardened memory macros.
  *
  * A synthesizable reference model is used when the PROP is DEFAULT. The
- * synthesizable model does not implement the cfg and test interface and should
+ * synthesizable model does not implement the ctrl interface and should
  * only be used for basic testing and for synthesizing for FPGA devices.
  * Advanced ASIC development should rely on complete functional models
  * supplied on a per macro basis.
@@ -22,11 +22,11 @@
 
 (* keep_hierarchy *)
 module {{ type }}
-  #(parameter DW     = 32,          // Memory width
-    parameter AW     = 10,          // Address width (derived)
-    parameter PROP   = "DEFAULT",   // Pass through variable for hard macro
-    parameter CTRLW  = 128,         // Width of asic ctrl interface
-    parameter TESTW  = 128          // Width of asic test interface
+  #(parameter DW      = 32,         // Memory width
+    parameter AW      = 10,         // Address width (derived)
+    parameter PROP    = "DEFAULT",  // Pass through variable for hard macro
+    parameter CTRLW   = 32,         // Width of ctrl interface
+    parameter STATUSW = 32          // Width of status interface
     )
    (// Memory interface
     input clk, // write clock
@@ -36,13 +36,10 @@ module {{ type }}
     input [AW-1:0] addr, //write address
     input [DW-1:0] din, //write data
     output [DW-1:0] dout, //read output data
-    // Power signals
-    input vss, // ground signal
-    input vdd, // memory core array power
-    input vddio, // periphery/io power
-    // Generic interfaces
-    input [CTRLW-1:0] ctrl, // pass through ASIC control interface
-    input [TESTW-1:0] test // pass through ASIC test interface
+    // Technology interfaces
+    input selctrl, // selects control interface
+    input [CTRLW-1:0] ctrl, // pass through control interface
+    output [STATUSW-1:0] status // pass through status interface
     );
 
     // Total number of bits
@@ -55,7 +52,7 @@ module {{ type }}
     localparam MEM_WIDTH = {% for memory, width in width_table %}
       (MEM_PROP == "{{ memory }}") ? {{ width }} :{% endfor %}
       0;
- 
+
     localparam MEM_DEPTH = {% for memory, depth in depth_table %}
       (MEM_PROP == "{{ memory }}") ? {{ depth }} :{% endfor %}
       0;
@@ -67,7 +64,7 @@ module {{ type }}
             .AW(AW),
             .PROP(PROP),
             .CTRLW(CTRLW),
-            .TESTW(TESTW)
+            .STATUSW(STATUSW)
         ) memory(
             .clk(clk),
             .ce(ce),
@@ -76,11 +73,9 @@ module {{ type }}
             .addr(addr),
             .din(din),
             .dout(dout),
-            .vss(vss),
-            .vdd(vdd),
-            .vddio(vddio),
+            .selctrl(selctrl),
             .ctrl(ctrl),
-            .test(test)
+            .status(status)
         );
       end
       if (MEM_PROP != "SOFT") begin: itech

--- a/lambdalib/ramlib/templates/la_tdprammemory.v
+++ b/lambdalib/ramlib/templates/la_tdprammemory.v
@@ -8,7 +8,7 @@
  * This is a wrapper for selecting from a set of hardened memory macros.
  *
  * A synthesizable reference model is used when the PROP is DEFAULT. The
- * synthesizable model does not implement the cfg and test interface and should
+ * synthesizable model does not implement the ctrl interface and should
  * only be used for basic testing and for synthesizing for FPGA devices.
  * Advanced ASIC development should rely on complete functional models
  * supplied on a per macro basis.
@@ -23,11 +23,11 @@
 (* keep_hierarchy *)
 module {{ type }}
   #(
-    parameter DW    = 32,         // Memory width
-    parameter AW    = 10,         // Address width (derived)
-    parameter PROP  = "DEFAULT",  // Pass through variable for hard macro
-    parameter CTRLW = 128,        // Width of asic ctrl interface
-    parameter TESTW = 128         // Width of asic test interface
+    parameter DW      = 32,         // Memory width
+    parameter AW      = 10,         // Address width (derived)
+    parameter PROP    = "DEFAULT",  // Pass through variable for hard macro
+    parameter CTRLW   = 32,         // Width of ctrl interface
+    parameter STATUSW = 32          // Width of status interface
   ) (  // Memory interface
       input               clk_a,    // write clock
       input               ce_a,     // write chip-enable
@@ -44,13 +44,10 @@ module {{ type }}
       input [AW-1:0]      addr_b,   // write address
       input [DW-1:0]      din_b,    // write data in
       output [DW-1:0]     dout_b,   // read data out
-      // Power signals
-      input vss,  // ground signal
-      input vdd,  // memory core array power
-      input vddio,  // periphery/io power
-      // Generic interfaces
-      input [CTRLW-1:0] ctrl,  // pass through ASIC control interface
-      input [TESTW-1:0] test  // pass through ASIC test interface
+      // Technology interfaces
+      input selctrl,  // selects control interface
+      input [CTRLW-1:0] ctrl,  // pass through control interface
+      output [STATUSW-1:0] status  // pass through status interface
   );
 
     // Total number of bits
@@ -63,7 +60,7 @@ module {{ type }}
     localparam MEM_WIDTH = {% for memory, width in width_table %}
       (MEM_PROP == "{{ memory }}") ? {{ width }} :{% endfor %}
       0;
- 
+
     localparam MEM_DEPTH = {% for memory, depth in depth_table %}
       (MEM_PROP == "{{ memory }}") ? {{ depth }} :{% endfor %}
       0;
@@ -75,7 +72,7 @@ module {{ type }}
             .AW(AW),
             .PROP(PROP),
             .CTRLW(CTRLW),
-            .TESTW(TESTW)
+            .STATUSW(STATUSW)
         ) memory (
             .clk_a(clk_a),
             .ce_a(ce_a),
@@ -91,11 +88,9 @@ module {{ type }}
             .addr_b(addr_b),
             .din_b(din_b),
             .dout_b(dout_b),
-            .vss(vss),
-            .vdd(vdd),
-            .vddio(vddio),
+            .selctrl(selctrl),
             .ctrl(ctrl),
-            .test(test)
+            .status(status)
         );
       end
       if (MEM_PROP != "SOFT") begin : itech


### PR DESCRIPTION
- power signals were not used anywhere and inconsistent with other cells so we are removing them. folks who want to do gate level type simulation while controlling the power supplies in verilog rather than upf will have to find way to wire up the supplies by another method.
- Removing the test interface, this is automatically inserted by a test tool
- Adding a status signal,as this will definitely be needed for advanced memory tech
- Adding a selctrl signal, because the lambdalib target implementation really needs to own the default hard coded safe settigs. The ctrl is for overriding those settings. Without this change we bleed tech information into the RTL code.