### PR TITLE
Making ramlib FPGA friendly

### DIFF
--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
@@ -26,6 +26,7 @@
 
 module la_dpram #(parameter DW = 32,          // Memory width
                   parameter AW = 10,          // address width (derived)
+                  parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
                   parameter PROP = "DEFAULT", // hard macro property
                   parameter CTRLW = 32,       // width of ctrl interface
                   parameter STATUSW = 32      // width of status interface
@@ -48,8 +49,26 @@ module la_dpram #(parameter DW = 32,          // Memory width
     output [STATUSW-1:0] status    // pass through status interface
     );
 
+   // In byte mode replicate byte-aligned mask bit wr_wmask[i*8] across its
+   // 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
+   // for-loop and the verilator mux consistent, and gives any hard macro a
+   // clean byte mask. Bit mode passes the per-bit mask through.
+   wire [DW-1:0] wr_wmask_int;
+   genvar gi;
+   generate
+      if (BYTEMODE) begin : g_bytemask
+         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
+            assign wr_wmask_int[gi*8+:8] = {8{wr_wmask[gi*8]}};
+         end
+      end
+      else begin : g_passthru
+         assign wr_wmask_int = wr_wmask;
+      end
+   endgenerate
+
    la_dpram_impl #(.DW      (DW),
                    .AW      (AW),
+                   .BYTEMODE(BYTEMODE),
                    .PROP    (PROP),
                    .CTRLW   (CTRLW),
                    .STATUSW (STATUSW)
@@ -58,7 +77,7 @@ module la_dpram #(parameter DW = 32,          // Memory width
            .wr_clk     (wr_clk),
            .wr_ce      (wr_ce),
            .wr_we      (wr_we),
-           .wr_wmask   (wr_wmask),
+           .wr_wmask   (wr_wmask_int),
            .wr_addr    (wr_addr),
            .wr_din     (wr_din),
            // read port
@@ -70,6 +89,5 @@ module la_dpram #(parameter DW = 32,          // Memory width
            .selctrl    (selctrl),
            .ctrl       (ctrl),
            .status     (status));
-
 
 endmodule

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -23,6 +23,7 @@
 module la_dpram_impl #(
                        parameter DW = 32,          // memory width
                        parameter AW = 10,          // address width (derived)
+                       parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
                        parameter PROP = "DEFAULT", // variable for hard macro
                        parameter CTRLW = 32,       // width of ctrl interface
                        parameter STATUSW = 32      // width of status interface
@@ -47,12 +48,37 @@ module la_dpram_impl #(
 
    // Generic RTL RAM
    reg     [DW-1:0] ram[(2**AW)-1:0];
-   integer          i;
 
-   // Write port
+`ifdef VERILATOR
+   // Fast equivalent ram write model (for ultra wide RAMs)
    always @(posedge wr_clk)
-     for (i = 0; i < DW; i = i + 1)
-       if (wr_ce & wr_we & wr_wmask[i]) ram[wr_addr[AW-1:0]][i] <= wr_din[i];
+     if (wr_ce & wr_we)
+       ram[wr_addr[AW-1:0]] <= (wr_din[DW-1:0] & wr_wmask[DW-1:0]) |
+                               (ram[wr_addr[AW-1:0]] & ~wr_wmask[DW-1:0]);
+`else
+   // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
+   // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
+   // 8-bit lane (byte-wide BRAM). In byte mode wr_wmask is byte-uniform (the
+   // la_dpram wrapper replicates wr_wmask[i*8]) and DW must be a multiple of 8.
+   generate
+      if (BYTEMODE) begin : g_bytemask
+         integer i;
+         always @(posedge wr_clk)
+           if (wr_ce & wr_we)
+             for (i = 0; i < DW/8; i = i + 1)
+               if (wr_wmask[i*8])
+                 ram[wr_addr[AW-1:0]][i*8+:8] <= wr_din[i*8+:8];
+      end
+      else begin : g_bitmask
+         integer i;
+         always @(posedge wr_clk)
+           if (wr_ce & wr_we)
+             for (i = 0; i < DW; i = i + 1)
+               if (wr_wmask[i])
+                 ram[wr_addr[AW-1:0]][i] <= wr_din[i];
+      end
+   endgenerate
+`endif
 
    // Read Port
    always @(posedge rd_clk) if (rd_ce) rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];

--- a/lambdalib/ramlib/la_spram/rtl/la_spram.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram.v
@@ -52,12 +52,14 @@ module la_spram #(parameter DW = 32,          // Memory width
    wire [DW-1:0] wmask_int;
    genvar gi;
    generate
-      if (BYTEMODE)
-        for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
-           assign wmask_int[gi*8+:8] = {8{wmask[gi*8]}};
-        end
-      else
-        assign wmask_int = wmask;
+      if (BYTEMODE) begin : g_bytemask
+         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
+            assign wmask_int[gi*8+:8] = {8{wmask[gi*8]}};
+         end
+      end
+      else begin : g_passthru
+         assign wmask_int = wmask;
+      end
    endgenerate
 
    la_spram_impl #(.DW      (DW),

--- a/lambdalib/ramlib/la_spram/rtl/la_spram.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram.v
@@ -26,7 +26,8 @@
 
 module la_spram #(parameter DW = 32,          // Memory width
                   parameter AW = 10,          // Address width (derived)
-                  parameter PROP = "DEFAULT", // variable for hard macro
+                  parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
+                  parameter PROP = "DEFAULT", // Variable for hard macro
                   parameter CTRLW = 32,       // width of ctrl interface
                   parameter STATUSW = 32      // width of status interface
                   )
@@ -44,8 +45,24 @@ module la_spram #(parameter DW = 32,          // Memory width
     output [STATUSW-1:0] status   // pass through status interface
     );
 
+   // In byte mode replicate byte-aligned mask bit wmask[i*8] across its
+   // 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
+   // for-loop and the verilator mux consistent, and gives any hard macro a
+   // clean byte mask. Bit mode passes the per-bit mask through.
+   wire [DW-1:0] wmask_int;
+   genvar gi;
+   generate
+      if (BYTEMODE)
+        for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
+           assign wmask_int[gi*8+:8] = {8{wmask[gi*8]}};
+        end
+      else
+        assign wmask_int = wmask;
+   endgenerate
+
    la_spram_impl #(.DW      (DW),
                    .AW      (AW),
+                   .BYTEMODE(BYTEMODE),
                    .PROP    (PROP),
                    .CTRLW   (CTRLW),
                    .STATUSW (STATUSW))
@@ -53,7 +70,7 @@ module la_spram #(parameter DW = 32,          // Memory width
            .clk    (clk),
            .ce     (ce),
            .we     (we),
-           .wmask  (wmask),
+           .wmask  (wmask_int),
            .addr   (addr),
            .din    (din),
            .dout   (dout),

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -22,6 +22,7 @@
 
 module la_spram_impl #(parameter DW = 32,          // memory width
                        parameter AW = 10,          // address width (derived)
+                       parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
                        parameter PROP = "DEFAULT", // variable for hard macro
                        parameter CTRLW = 32,       // width of ctrl interface
                        parameter STATUSW = 32      // width of status interface
@@ -43,17 +44,37 @@ module la_spram_impl #(parameter DW = 32,          // memory width
     // Generic RTL RAM
    reg     [DW-1:0] ram[(2**AW)-1:0];
 
-    // Write port
-    //   always @(posedge clk)
-    //     for (i=0;i<DW;i=i+1)
-    //       if (ce & we & wmask[i])
-    //         ram[addr[AW-1:0]][i] <= din[i];
 
-    // Re-writing as a mux for verilator
+`ifdef VERILATOR
+    // Fast requivalent ram write model (for ultra wide RAMs)
     always @(posedge clk)
       if (ce & we)
         ram[addr[AW-1:0]] <= (din[DW-1:0] & wmask[DW-1:0]) |
                              (ram[addr[AW-1:0]] & ~wmask[DW-1:0]);
+`else
+    // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
+    // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
+    // 8-bit lane (byte-wide BRAM). In byte mode wmask is byte-uniform (the
+    // la_spram wrapper replicates wmask[i*8]) and DW must be a multiple of 8.
+    generate
+      if (BYTEMODE) begin : g_bytemask
+         integer i;
+         always @(posedge clk)
+           if (ce & we)
+             for (i = 0; i < DW/8; i = i + 1)
+               if (wmask[i*8])
+                 ram[addr[AW-1:0]][i*8+:8] <= din[i*8+:8];
+      end
+      else begin : g_bitmask
+         integer i;
+         always @(posedge clk)
+           if (ce & we)
+             for (i = 0; i < DW; i = i + 1)
+               if (wmask[i])
+                 ram[addr[AW-1:0]][i] <= din[i];
+      end
+    endgenerate
+`endif
 
     // Read Port
     always @(posedge clk)

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
@@ -22,6 +22,7 @@
 
 module la_tdpram #(parameter DW = 32,          // Memory width
                    parameter AW = 10,          // Address width (derived)
+                   parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
                    parameter PROP = "DEFAULT", // variable for hard macro
                    parameter CTRLW = 32,       // width of ctrl interface
                    parameter STATUSW = 32      // width of status interface
@@ -48,8 +49,29 @@ module la_tdpram #(parameter DW = 32,          // Memory width
     output [STATUSW-1:0] status   // pass through status interface
     );
 
+   // In byte mode replicate each byte-aligned mask bit (wmask_x[i*8]) across
+   // its 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
+   // for-loop and the verilator mux consistent, and gives any hard macro a
+   // clean byte mask. Bit mode passes the per-bit masks through.
+   wire [DW-1:0] wmask_a_int;
+   wire [DW-1:0] wmask_b_int;
+   genvar gi;
+   generate
+      if (BYTEMODE) begin : g_bytemask
+         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
+            assign wmask_a_int[gi*8+:8] = {8{wmask_a[gi*8]}};
+            assign wmask_b_int[gi*8+:8] = {8{wmask_b[gi*8]}};
+         end
+      end
+      else begin : g_passthru
+         assign wmask_a_int = wmask_a;
+         assign wmask_b_int = wmask_b;
+      end
+   endgenerate
+
    la_tdpram_impl #(.DW      (DW),
                     .AW      (AW),
+                    .BYTEMODE(BYTEMODE),
                     .PROP    (PROP),
                     .CTRLW   (CTRLW),
                     .STATUSW (STATUSW))
@@ -57,7 +79,7 @@ module la_tdpram #(parameter DW = 32,          // Memory width
            .clk_a      (clk_a),
            .ce_a       (ce_a),
            .we_a       (we_a),
-           .wmask_a    (wmask_a),
+           .wmask_a    (wmask_a_int),
            .addr_a     (addr_a),
            .din_a      (din_a),
            .dout_a     (dout_a),
@@ -65,7 +87,7 @@ module la_tdpram #(parameter DW = 32,          // Memory width
            .clk_b      (clk_b),
            .ce_b       (ce_b),
            .we_b       (we_b),
-           .wmask_b    (wmask_b),
+           .wmask_b    (wmask_b_int),
            .addr_b     (addr_b),
            .din_b      (din_b),
            .dout_b     (dout_b),

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -22,6 +22,7 @@
 
 module la_tdpram_impl #(parameter DW = 32,          // Memory width
                         parameter AW = 10,          // Address width (derived)
+                        parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
                         parameter PROP = "DEFAULT", // variable for hard macro
                         parameter CTRLW = 32,       // width of ctrl interface
                         parameter STATUSW = 32      // width of status interface
@@ -53,25 +54,60 @@ module la_tdpram_impl #(parameter DW = 32,          // Memory width
    reg [DW-1:0]       ram[(2**AW)-1:0];
    /* verilator lint_on MULTIDRIVEN */
 
-   integer            i;
+`ifdef VERILATOR
+   // Fast equivalent ram write model (for ultra wide RAMs)
+   always @(posedge clk_a)
+     if (ce_a & we_a)
+       ram[addr_a] <= (din_a & wmask_a) | (ram[addr_a] & ~wmask_a);
+   always @(posedge clk_b)
+     if (ce_b & we_b)
+       ram[addr_b] <= (din_b & wmask_b) | (ram[addr_b] & ~wmask_b);
+`else
+   // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
+   // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
+   // 8-bit lane (byte-wide BRAM). In byte mode the masks are byte-uniform (the
+   // la_tdpram wrapper replicates wmask_x[i*8]) and DW must be a multiple of 8.
 
    // Port A write
-   always @(posedge clk_a) begin
-      for (i = 0; i < DW; i = i + 1) begin
-         if (ce_a && we_a && wmask_a[i]) begin
-            ram[addr_a][i] <= din_a[i];
-         end
+   generate
+      if (BYTEMODE) begin : g_bytemask_a
+         integer i;
+         always @(posedge clk_a)
+           if (ce_a & we_a)
+             for (i = 0; i < DW/8; i = i + 1)
+               if (wmask_a[i*8])
+                 ram[addr_a][i*8+:8] <= din_a[i*8+:8];
       end
-   end
+      else begin : g_bitmask_a
+         integer i;
+         always @(posedge clk_a)
+           if (ce_a & we_a)
+             for (i = 0; i < DW; i = i + 1)
+               if (wmask_a[i])
+                 ram[addr_a][i] <= din_a[i];
+      end
+   endgenerate
 
    // Port B write
-   always @(posedge clk_b) begin
-      for (i = 0; i < DW; i = i + 1) begin
-         if (ce_b && we_b && wmask_b[i]) begin
-            ram[addr_b][i] <= din_b[i];
-         end
+   generate
+      if (BYTEMODE) begin : g_bytemask_b
+         integer i;
+         always @(posedge clk_b)
+           if (ce_b & we_b)
+             for (i = 0; i < DW/8; i = i + 1)
+               if (wmask_b[i*8])
+                 ram[addr_b][i*8+:8] <= din_b[i*8+:8];
       end
-   end
+      else begin : g_bitmask_b
+         integer i;
+         always @(posedge clk_b)
+           if (ce_b & we_b)
+             for (i = 0; i < DW; i = i + 1)
+               if (wmask_b[i])
+                 ram[addr_b][i] <= din_b[i];
+      end
+   endgenerate
+`endif
 
    // Port A read
    always @(posedge clk_a) begin


### PR DESCRIPTION
The current bitmask based rams are fine for ASICs but don't map well to FPGAs which are generally byte enable only.
This PR fixes that.