### PR TITLE
Fixing bytemask interface

### DIFF
--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram.v
@@ -24,51 +24,34 @@
  *
  ****************************************************************************/
 
-module la_dpram #(parameter DW = 32,          // Memory width
-                  parameter AW = 10,          // address width (derived)
-                  parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
-                  parameter PROP = "DEFAULT", // hard macro property
+module la_dpram #(parameter DW = 32,          // memory width
+                  parameter AW = 10,          // address width
+                  parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
+                  parameter PROP = "DEFAULT", // variable for hard macro
                   parameter CTRLW = 32,       // width of ctrl interface
                   parameter STATUSW = 32      // width of status interface
                   )
    (// Write port
-    input               wr_clk,   // write clock
-    input               wr_ce,    // write chip-enable
-    input               wr_we,    // write enable
-    input [DW-1:0]      wr_wmask, // write mask
-    input [AW-1:0]      wr_addr,  // write address
-    input [DW-1:0]      wr_din,   //write data in
+    input                          wr_clk,   // write clock
+    input                          wr_ce,    // write chip-enable
+    input                          wr_we,    // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wr_wmask, // bit or byte write mask
+    input [AW-1:0]                 wr_addr,  // write address
+    input [DW-1:0]                 wr_din,   //write data in
     // Read port
-    input               rd_clk,   // read clock
-    input               rd_ce,    // read chip-enable
-    input [AW-1:0]      rd_addr,  // read address
-    output [DW-1:0]     rd_dout,  //read data out
+    input                          rd_clk,   // read clock
+    input                          rd_ce,    // read chip-enable
+    input [AW-1:0]                 rd_addr,  // read address
+    output [DW-1:0]                rd_dout,  //read data out
     // Generic interfaces
-    input               selctrl,  // selects control interface
-    input [CTRLW-1:0]   ctrl,     // pass through control interface
-    output [STATUSW-1:0] status    // pass through status interface
+    input                          selctrl,  // selects control interface
+    input [CTRLW-1:0]              ctrl,     // pass through control interface
+    output [STATUSW-1:0]           status    // pass through status interface
     );
-
-   // In byte mode replicate byte-aligned mask bit wr_wmask[i*8] across its
-   // 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
-   // for-loop and the verilator mux consistent, and gives any hard macro a
-   // clean byte mask. Bit mode passes the per-bit mask through.
-   wire [DW-1:0] wr_wmask_int;
-   genvar gi;
-   generate
-      if (BYTEMODE) begin : g_bytemask
-         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
-            assign wr_wmask_int[gi*8+:8] = {8{wr_wmask[gi*8]}};
-         end
-      end
-      else begin : g_passthru
-         assign wr_wmask_int = wr_wmask;
-      end
-   endgenerate
 
    la_dpram_impl #(.DW      (DW),
                    .AW      (AW),
-                   .BYTEMODE(BYTEMODE),
+                   .BYTEMASK(BYTEMASK),
                    .PROP    (PROP),
                    .CTRLW   (CTRLW),
                    .STATUSW (STATUSW)
@@ -77,7 +60,7 @@ module la_dpram #(parameter DW = 32,          // Memory width
            .wr_clk     (wr_clk),
            .wr_ce      (wr_ce),
            .wr_we      (wr_we),
-           .wr_wmask   (wr_wmask_int),
+           .wr_wmask   (wr_wmask),
            .wr_addr    (wr_addr),
            .wr_din     (wr_din),
            // read port
@@ -85,7 +68,7 @@ module la_dpram #(parameter DW = 32,          // Memory width
            .rd_ce      (rd_ce),
            .rd_addr    (rd_addr),
            .rd_dout    (rd_dout),
-           // ctrl
+           // Technology interfaces
            .selctrl    (selctrl),
            .ctrl       (ctrl),
            .status     (status));

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -49,9 +49,10 @@ module la_dpram_impl #(
    // Generic RTL RAM
    reg     [DW-1:0] ram[(2**AW)-1:0];
 
-   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
-   // mask bit across its 8-bit lane to form a byte-uniform DW-wide mask for
-   // the reference model. Bit mode passes the per-bit mask through.
+`ifdef VERILATOR
+   // Fast equivalent ram write model (for ultra wide RAMs). The vectorized
+   // AND/OR needs a full DW-wide bit mask, so byte mode replicates each mask
+   // bit across its 8-bit lane; bit mode passes the per-bit mask through.
    wire [DW-1:0] wr_wmask_int;
    genvar gwm;
    generate
@@ -65,24 +66,21 @@ module la_dpram_impl #(
       end
    endgenerate
 
-`ifdef VERILATOR
-   // Fast equivalent ram write model (for ultra wide RAMs)
    always @(posedge wr_clk)
      if (wr_ce & wr_we)
        ram[wr_addr[AW-1:0]] <= (wr_din[DW-1:0]       &  wr_wmask_int[DW-1:0]) |
                                (ram[wr_addr[AW-1:0]] & ~wr_wmask_int[DW-1:0]);
 `else
    // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
-   // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
-   // In byte mode wr_wmask_int is byte-uniform (replicated above) and DW
-   // must be a multiple of 8.
+   // granularity: per 8-bit lane (byte-wide BRAM) or per-bit (hard macro).
+   // In byte mode wr_wmask is DW/8-wide and DW must be a multiple of 8.
    generate
       if (BYTEMASK) begin : g_bytemask
          integer i;
          always @(posedge wr_clk)
            if (wr_ce & wr_we)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wr_wmask_int[i*8])
+               if (wr_wmask[i])
                  ram[wr_addr[AW-1:0]][i*8+:8] <= wr_din[i*8+:8];
       end
       else begin : g_bitmask
@@ -90,7 +88,7 @@ module la_dpram_impl #(
          always @(posedge wr_clk)
            if (wr_ce & wr_we)
              for (i = 0; i < DW; i = i + 1)
-               if (wr_wmask_int[i])
+               if (wr_wmask[i])
                  ram[wr_addr[AW-1:0]][i] <= wr_din[i];
       end
    endgenerate

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -29,21 +29,21 @@ module la_dpram_impl #(
                        parameter STATUSW = 32      // width of status interface
                        )
    (// Write port
-    input               wr_clk,   // write clock
-    input               wr_ce,    // write chip-enable
-    input               wr_we,    // write enable
-    input [(BYTEMASK ? DW/8 : DW)-1:0] wr_wmask, // bit or byte write mask
-    input [AW-1:0]      wr_addr,  // write address
-    input [DW-1:0]      wr_din,   //write data in
+    input                          wr_clk,   // write clock
+    input                          wr_ce,    // write chip-enable
+    input                          wr_we,    // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wr_wmask, // bit or byte write mask
+    input [AW-1:0]                 wr_addr,  // write address
+    input [DW-1:0]                 wr_din,   //write data in
     // Read port
-    input               rd_clk,   // read clock
-    input               rd_ce,    // read chip-enable
-    input [AW-1:0]      rd_addr,  // read address
-    output reg [DW-1:0] rd_dout,  //read data out
+    input                          rd_clk,   // read clock
+    input                          rd_ce,    // read chip-enable
+    input [AW-1:0]                 rd_addr,  // read address
+    output reg [DW-1:0]            rd_dout,  //read data out
     // Technology interfaces
-    input               selctrl,  // selects control interface
-    input [CTRLW-1:0]   ctrl,     // pass through control interface
-    output [STATUSW-1:0] status    // pass through status interface
+    input                          selctrl,  // selects control interface
+    input [CTRLW-1:0]              ctrl,     // control interface
+    output [STATUSW-1:0]           status    // status interface
     );
 
    // Generic RTL RAM
@@ -97,7 +97,9 @@ module la_dpram_impl #(
 `endif
 
    // Read Port
-   always @(posedge rd_clk) if (rd_ce) rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
+   always @(posedge rd_clk)
+     if (rd_ce)
+       rd_dout[DW-1:0] <= ram[rd_addr[AW-1:0]];
 
    // Status (active in hard macro, tied off in soft model)
    assign status = {STATUSW{1'b0}};

--- a/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
+++ b/lambdalib/ramlib/la_dpram/rtl/la_dpram_impl.v
@@ -22,8 +22,8 @@
 
 module la_dpram_impl #(
                        parameter DW = 32,          // memory width
-                       parameter AW = 10,          // address width (derived)
-                       parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
+                       parameter AW = 10,          // address width
+                       parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                        parameter PROP = "DEFAULT", // variable for hard macro
                        parameter CTRLW = 32,       // width of ctrl interface
                        parameter STATUSW = 32      // width of status interface
@@ -32,7 +32,7 @@ module la_dpram_impl #(
     input               wr_clk,   // write clock
     input               wr_ce,    // write chip-enable
     input               wr_we,    // write enable
-    input [DW-1:0]      wr_wmask, // write mask
+    input [(BYTEMASK ? DW/8 : DW)-1:0] wr_wmask, // bit or byte write mask
     input [AW-1:0]      wr_addr,  // write address
     input [DW-1:0]      wr_din,   //write data in
     // Read port
@@ -49,24 +49,40 @@ module la_dpram_impl #(
    // Generic RTL RAM
    reg     [DW-1:0] ram[(2**AW)-1:0];
 
+   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
+   // mask bit across its 8-bit lane to form a byte-uniform DW-wide mask for
+   // the reference model. Bit mode passes the per-bit mask through.
+   wire [DW-1:0] wr_wmask_int;
+   genvar gwm;
+   generate
+      if (BYTEMASK) begin : g_wm_byte
+         for (gwm = 0; gwm < DW/8; gwm = gwm + 1) begin : g_wm_lane
+            assign wr_wmask_int[gwm*8+:8] = {8{wr_wmask[gwm]}};
+         end
+      end
+      else begin : g_wm_bit
+         assign wr_wmask_int = wr_wmask;
+      end
+   endgenerate
+
 `ifdef VERILATOR
    // Fast equivalent ram write model (for ultra wide RAMs)
    always @(posedge wr_clk)
      if (wr_ce & wr_we)
-       ram[wr_addr[AW-1:0]] <= (wr_din[DW-1:0] & wr_wmask[DW-1:0]) |
-                               (ram[wr_addr[AW-1:0]] & ~wr_wmask[DW-1:0]);
+       ram[wr_addr[AW-1:0]] <= (wr_din[DW-1:0]       &  wr_wmask_int[DW-1:0]) |
+                               (ram[wr_addr[AW-1:0]] & ~wr_wmask_int[DW-1:0]);
 `else
-   // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
-   // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
-   // 8-bit lane (byte-wide BRAM). In byte mode wr_wmask is byte-uniform (the
-   // la_dpram wrapper replicates wr_wmask[i*8]) and DW must be a multiple of 8.
+   // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
+   // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
+   // In byte mode wr_wmask_int is byte-uniform (replicated above) and DW
+   // must be a multiple of 8.
    generate
-      if (BYTEMODE) begin : g_bytemask
+      if (BYTEMASK) begin : g_bytemask
          integer i;
          always @(posedge wr_clk)
            if (wr_ce & wr_we)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wr_wmask[i*8])
+               if (wr_wmask_int[i*8])
                  ram[wr_addr[AW-1:0]][i*8+:8] <= wr_din[i*8+:8];
       end
       else begin : g_bitmask
@@ -74,7 +90,7 @@ module la_dpram_impl #(
          always @(posedge wr_clk)
            if (wr_ce & wr_we)
              for (i = 0; i < DW; i = i + 1)
-               if (wr_wmask[i])
+               if (wr_wmask_int[i])
                  ram[wr_addr[AW-1:0]][i] <= wr_din[i];
       end
    endgenerate

--- a/lambdalib/ramlib/la_spram/rtl/la_spram.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram.v
@@ -24,61 +24,44 @@
  *
  ****************************************************************************/
 
-module la_spram #(parameter DW = 32,          // Memory width
-                  parameter AW = 10,          // Address width (derived)
-                  parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
-                  parameter PROP = "DEFAULT", // Variable for hard macro
+module la_spram #(parameter DW = 32,          // memory width
+                  parameter AW = 10,          // address width
+                  parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
+                  parameter PROP = "DEFAULT", // variable for hard macro
                   parameter CTRLW = 32,       // width of ctrl interface
                   parameter STATUSW = 32      // width of status interface
                   )
    (// Memory interface
-    input               clk,     // write clock
-    input               ce,      // chip enable
-    input               we,      // write enable
-    input [DW-1:0]      wmask,   //per bit write mask
-    input [AW-1:0]      addr,    //write address
-    input [DW-1:0]      din,     //write data
-    output [DW-1:0]     dout,    //read output data
+    input                          clk,     // write clock
+    input                          ce,      // chip enable
+    input                          we,      // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask,   // bit or byte write mask
+    input [AW-1:0]                 addr,    //write address
+    input [DW-1:0]                 din,     //write data
+    output [DW-1:0]                dout,    //read output data
     // Technology interfaces
-    input               selctrl, // selects control interface
-    input [CTRLW-1:0]   ctrl,    // pass through control interface
-    output [STATUSW-1:0] status   // pass through status interface
+    input                          selctrl, // selects control interface
+    input [CTRLW-1:0]              ctrl,    // pass through control interface
+    output [STATUSW-1:0]           status   // pass through status interface
     );
-
-   // In byte mode replicate byte-aligned mask bit wmask[i*8] across its
-   // 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
-   // for-loop and the verilator mux consistent, and gives any hard macro a
-   // clean byte mask. Bit mode passes the per-bit mask through.
-   wire [DW-1:0] wmask_int;
-   genvar gi;
-   generate
-      if (BYTEMODE) begin : g_bytemask
-         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
-            assign wmask_int[gi*8+:8] = {8{wmask[gi*8]}};
-         end
-      end
-      else begin : g_passthru
-         assign wmask_int = wmask;
-      end
-   endgenerate
 
    la_spram_impl #(.DW      (DW),
                    .AW      (AW),
-                   .BYTEMODE(BYTEMODE),
+                   .BYTEMASK(BYTEMASK),
                    .PROP    (PROP),
                    .CTRLW   (CTRLW),
                    .STATUSW (STATUSW))
-   memory (// port
-           .clk    (clk),
-           .ce     (ce),
-           .we     (we),
-           .wmask  (wmask_int),
-           .addr   (addr),
-           .din    (din),
-           .dout   (dout),
-           // macro interface
-           .selctrl    (selctrl),
-           .ctrl       (ctrl),
-           .status     (status));
+   memory (// Memory interface
+           .clk      (clk),
+           .ce       (ce),
+           .we       (we),
+           .wmask    (wmask),
+           .addr     (addr),
+           .din      (din),
+           .dout     (dout),
+           // Technology interfaces
+           .selctrl  (selctrl),
+           .ctrl     (ctrl),
+           .status   (status));
 
 endmodule

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -44,12 +44,13 @@ module la_spram_impl #(parameter DW = 32,          // memory width
    // Generic RTL RAM
    reg [DW-1:0]  ram[(2**AW)-1:0];
 
-   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
-   // mask bit across its 8-bit lane to form a byte-uniform DW-wide mask for
-   // the reference model. Bit mode passes the per-bit mask through.
-   wire [DW-1:0] wmask_int;
-   genvar gwm;
-   generate
+`ifdef VERILATOR
+    // Fast equivalent ram write model (for ultra wide RAMs). The vectorized
+    // AND/OR needs a full DW-wide bit mask, so byte mode replicates each mask
+    // bit across its 8-bit lane; bit mode passes the per-bit mask through.
+    wire [DW-1:0] wmask_int;
+    genvar gwm;
+    generate
       if (BYTEMASK) begin : g_wm_byte
          for (gwm = 0; gwm < DW/8; gwm = gwm + 1) begin : g_wm_lane
             assign wmask_int[gwm*8+:8] = {8{wmask[gwm]}};
@@ -58,26 +59,23 @@ module la_spram_impl #(parameter DW = 32,          // memory width
       else begin : g_wm_bit
          assign wmask_int = wmask;
       end
-   endgenerate
+    endgenerate
 
-`ifdef VERILATOR
-    // Fast requivalent ram write model (for ultra wide RAMs)
     always @(posedge clk)
       if (ce & we)
         ram[addr[AW-1:0]] <= (din[DW-1:0]       &  wmask_int[DW-1:0]) |
                              (ram[addr[AW-1:0]] & ~wmask_int[DW-1:0]);
 `else
     // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
-    // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
-    // In byte mode wmask_int is byte-uniform (replicated above) and DW
-    // must be a multiple of 8.
+    // granularity: per 8-bit lane (byte-wide BRAM) or per-bit (hard macro).
+    // In byte mode wmask is DW/8-wide and DW must be a multiple of 8.
     generate
       if (BYTEMASK) begin : g_bytemask
          integer i;
          always @(posedge clk)
            if (ce & we)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask_int[i*8])
+               if (wmask[i])
                  ram[addr[AW-1:0]][i*8+:8] <= din[i*8+:8];
       end
       else begin : g_bitmask
@@ -85,7 +83,7 @@ module la_spram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk)
            if (ce & we)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask_int[i])
+               if (wmask[i])
                  ram[addr[AW-1:0]][i] <= din[i];
       end
     endgenerate

--- a/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
+++ b/lambdalib/ramlib/la_spram/rtl/la_spram_impl.v
@@ -21,48 +21,63 @@
  ****************************************************************************/
 
 module la_spram_impl #(parameter DW = 32,          // memory width
-                       parameter AW = 10,          // address width (derived)
-                       parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
+                       parameter AW = 10,          // address width
+                       parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                        parameter PROP = "DEFAULT", // variable for hard macro
                        parameter CTRLW = 32,       // width of ctrl interface
                        parameter STATUSW = 32      // width of status interface
                        )
    (// Memory interface
-    input               clk,     // write clock
-    input               ce,      // chip enable
-    input               we,      // write enable
-    input [DW-1:0]      wmask,   //per bit write mask
-    input [AW-1:0]      addr,    //write address
-    input [DW-1:0]      din,     //write data
-    output reg [DW-1:0] dout,    //read output data
+    input                          clk,     // write clock
+    input                          ce,      // chip enable
+    input                          we,      // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask,   // bit or byte write mask
+    input [AW-1:0]                 addr,    //write address
+    input [DW-1:0]                 din,     //write data
+    output reg [DW-1:0]            dout,    //read output data
     // Technology interfaces
-    input               selctrl, // selects control interface
-    input [CTRLW-1:0]   ctrl,    // pass through control interface
-    output [STATUSW-1:0] status   // pass through status interface
+    input                          selctrl, // selects control interface
+    input [CTRLW-1:0]              ctrl,    // pass through control interface
+    output [STATUSW-1:0]           status   // pass through status interface
     );
 
-    // Generic RTL RAM
-   reg     [DW-1:0] ram[(2**AW)-1:0];
+   // Generic RTL RAM
+   reg [DW-1:0]  ram[(2**AW)-1:0];
 
+   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
+   // mask bit across its 8-bit lane to form a byte-uniform DW-wide mask for
+   // the reference model. Bit mode passes the per-bit mask through.
+   wire [DW-1:0] wmask_int;
+   genvar gwm;
+   generate
+      if (BYTEMASK) begin : g_wm_byte
+         for (gwm = 0; gwm < DW/8; gwm = gwm + 1) begin : g_wm_lane
+            assign wmask_int[gwm*8+:8] = {8{wmask[gwm]}};
+         end
+      end
+      else begin : g_wm_bit
+         assign wmask_int = wmask;
+      end
+   endgenerate
 
 `ifdef VERILATOR
     // Fast requivalent ram write model (for ultra wide RAMs)
     always @(posedge clk)
       if (ce & we)
-        ram[addr[AW-1:0]] <= (din[DW-1:0] & wmask[DW-1:0]) |
-                             (ram[addr[AW-1:0]] & ~wmask[DW-1:0]);
+        ram[addr[AW-1:0]] <= (din[DW-1:0]       &  wmask_int[DW-1:0]) |
+                             (ram[addr[AW-1:0]] & ~wmask_int[DW-1:0]);
 `else
-    // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
-    // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
-    // 8-bit lane (byte-wide BRAM). In byte mode wmask is byte-uniform (the
-    // la_spram wrapper replicates wmask[i*8]) and DW must be a multiple of 8.
+    // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
+    // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
+    // In byte mode wmask_int is byte-uniform (replicated above) and DW
+    // must be a multiple of 8.
     generate
-      if (BYTEMODE) begin : g_bytemask
+      if (BYTEMASK) begin : g_bytemask
          integer i;
          always @(posedge clk)
            if (ce & we)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask[i*8])
+               if (wmask_int[i*8])
                  ram[addr[AW-1:0]][i*8+:8] <= din[i*8+:8];
       end
       else begin : g_bitmask
@@ -70,7 +85,7 @@ module la_spram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk)
            if (ce & we)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask[i])
+               if (wmask_int[i])
                  ram[addr[AW-1:0]][i] <= din[i];
       end
     endgenerate

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile.v
@@ -22,18 +22,19 @@
 
 module la_spregfile #(parameter DW = 32,          // Memory width
                       parameter AW = 10,          // Address width (derived)
+                      parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                       parameter PROP = "DEFAULT", // variable for hard macro
                       parameter CTRLW = 32,       // width of ctrl interface
                       parameter STATUSW = 32      // width of status interface
                       )
    (// Memory interface
-    input               clk,     // write clock
-    input               ce,      // chip enable
-    input               we,      // write enable
-    input [DW-1:0]      wmask,   // per bit write mask
-    input [AW-1:0]      addr,    // write address
-    input [DW-1:0]      din,     // write data
-    output [DW-1:0]     dout,    // read output data
+    input                          clk,     // write clock
+    input                          ce,      // chip enable
+    input                          we,      // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask,   // bit or byte write mask
+    input [AW-1:0]                 addr,    // write address
+    input [DW-1:0]                 din,     // write data
+    output [DW-1:0]                dout,    // read output data
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
@@ -42,6 +43,7 @@ module la_spregfile #(parameter DW = 32,          // Memory width
 
    la_spregfile_impl #(.DW      (DW),
                        .AW      (AW),
+                       .BYTEMASK(BYTEMASK),
                        .PROP    (PROP),
                        .CTRLW   (CTRLW),
                        .STATUSW (STATUSW))

--- a/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
+++ b/lambdalib/ramlib/la_spregfile/rtl/la_spregfile_impl.v
@@ -22,18 +22,19 @@
 
 module la_spregfile_impl #(parameter DW = 32,          // Memory width
                            parameter AW = 10,          // Address width (derived)
+                           parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                            parameter PROP = "DEFAULT", // variable for hard macro
                            parameter CTRLW = 32,       // width of ctrl interface
                            parameter STATUSW = 32      // width of status interface
                            )
    (// Memory interface
-    input               clk,     // write clock
-    input               ce,      // chip enable
-    input               we,      // write enable
-    input [DW-1:0]      wmask,   // per bit write mask
-    input [AW-1:0]      addr,    // write address
-    input [DW-1:0]      din,     // write data
-    output reg [DW-1:0] dout,    // read output data
+    input                          clk,     // write clock
+    input                          ce,      // chip enable
+    input                          we,      // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask,   // bit or byte write mask
+    input [AW-1:0]                 addr,    // write address
+    input [DW-1:0]                 din,     // write data
+    output reg [DW-1:0]            dout,    // read output data
     // Technology interfaces
     input               selctrl, // selects control interface
     input [CTRLW-1:0]   ctrl,    // pass through control interface
@@ -43,17 +44,50 @@ module la_spregfile_impl #(parameter DW = 32,          // Memory width
     // Generic RTL RAM
    reg     [DW-1:0] ram[(2**AW)-1:0];
 
-    // Write port
-    //   always @(posedge clk)
-    //     for (i=0;i<DW;i=i+1)
-    //       if (ce & we & wmask[i])
-    //         ram[addr[AW-1:0]][i] <= din[i];
+`ifdef VERILATOR
+    // Fast equivalent ram write model (for ultra wide RAMs). The vectorized
+    // AND/OR needs a full DW-wide bit mask, so byte mode replicates each mask
+    // bit across its 8-bit lane; bit mode passes the per-bit mask through.
+    wire [DW-1:0] wmask_int;
+    genvar gwm;
+    generate
+      if (BYTEMASK) begin : g_wm_byte
+         for (gwm = 0; gwm < DW/8; gwm = gwm + 1) begin : g_wm_lane
+            assign wmask_int[gwm*8+:8] = {8{wmask[gwm]}};
+         end
+      end
+      else begin : g_wm_bit
+         assign wmask_int = wmask;
+      end
+    endgenerate
 
-    // Re-writing as a mux for verilator
     always @(posedge clk)
       if (ce & we)
-        ram[addr[AW-1:0]] <= (din[DW-1:0] & wmask[DW-1:0]) |
-                             (ram[addr[AW-1:0]] & ~wmask[DW-1:0]);
+        ram[addr[AW-1:0]] <= (din[DW-1:0]       &  wmask_int[DW-1:0]) |
+                             (ram[addr[AW-1:0]] & ~wmask_int[DW-1:0]);
+`else
+    // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
+    // granularity: per 8-bit lane (byte-wide BRAM) or per-bit (hard macro).
+    // In byte mode wmask is DW/8-wide and DW must be a multiple of 8.
+    generate
+      if (BYTEMASK) begin : g_bytemask
+         integer i;
+         always @(posedge clk)
+           if (ce & we)
+             for (i = 0; i < DW/8; i = i + 1)
+               if (wmask[i])
+                 ram[addr[AW-1:0]][i*8+:8] <= din[i*8+:8];
+      end
+      else begin : g_bitmask
+         integer i;
+         always @(posedge clk)
+           if (ce & we)
+             for (i = 0; i < DW; i = i + 1)
+               if (wmask[i])
+                 ram[addr[AW-1:0]][i] <= din[i];
+      end
+    endgenerate
+`endif
 
     // Read Port
     always @(posedge clk)

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram.v
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Function:
+ * Function: True Dual Port RAM (Two write + read ports)
  * Copyright: Lambda Project Authors. All rights Reserved.
  * License:  MIT (see LICENSE file in Lambda repository)
  *
@@ -15,83 +15,67 @@
  *
  * Technology specific implementations of "la_tdpram" would generally include
  * one or more hardcoded instantiations of RAM modules with a generate
- * statement relying on the "PROP" to select between the list of modules
- * at build time.
+ * statement relying on the "PROP", AW, and DW to select between the list of
+ * modules at build time.
+ *
+ * The 'selctrl' signal tells the implementation to select the ctrl interface
+ * if set to one, otherwise hard coded tech specific parameters inside the
+ * lambdalib implementations are used to control the RAM.
  *
  ****************************************************************************/
 
-module la_tdpram #(parameter DW = 32,          // Memory width
-                   parameter AW = 10,          // Address width (derived)
-                   parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask(def)
+module la_tdpram #(parameter DW = 32,          // memory width
+                   parameter AW = 10,          // address width
+                   parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                    parameter PROP = "DEFAULT", // variable for hard macro
                    parameter CTRLW = 32,       // width of ctrl interface
                    parameter STATUSW = 32      // width of status interface
                    )
    (// A port
-    input               clk_a,   // write clock
-    input               ce_a,    // write chip-enable
-    input               we_a,    // write enable
-    input [DW-1:0]      wmask_a, // write mask
-    input [AW-1:0]      addr_a,  // write address
-    input [DW-1:0]      din_a,   // write data in
-    output [DW-1:0]     dout_a,  // read data out
+    input                          clk_a,   // write clock
+    input                          ce_a,    // write chip-enable
+    input                          we_a,    // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask_a, // bit or byte write mask
+    input [AW-1:0]                 addr_a,  // write address
+    input [DW-1:0]                 din_a,   // write data in
+    output [DW-1:0]                dout_a,  // read data out
     // B port
-    input               clk_b,   // write clock
-    input               ce_b,    // write chip-enable
-    input               we_b,    // write enable
-    input [DW-1:0]      wmask_b, // write mask
-    input [AW-1:0]      addr_b,  // write address
-    input [DW-1:0]      din_b,   // write data in
-    output [DW-1:0]     dout_b,  // read data out
+    input                          clk_b,   // write clock
+    input                          ce_b,    // write chip-enable
+    input                          we_b,    // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0] wmask_b, // bit or byte write mask
+    input [AW-1:0]                 addr_b,  // write address
+    input [DW-1:0]                 din_b,   // write data in
+    output [DW-1:0]                dout_b,  // read data out
     // Technology interfaces
-    input               selctrl, // selects control interface
-    input [CTRLW-1:0]   ctrl,    // pass through control interface
-    output [STATUSW-1:0] status   // pass through status interface
+    input                          selctrl, // selects control interface
+    input [CTRLW-1:0]              ctrl,    // control interface
+    output [STATUSW-1:0]           status   // status interface
     );
-
-   // In byte mode replicate each byte-aligned mask bit (wmask_x[i*8]) across
-   // its 8-bit lane so the lane is byte-uniform. This keeps the synthesis byte
-   // for-loop and the verilator mux consistent, and gives any hard macro a
-   // clean byte mask. Bit mode passes the per-bit masks through.
-   wire [DW-1:0] wmask_a_int;
-   wire [DW-1:0] wmask_b_int;
-   genvar gi;
-   generate
-      if (BYTEMODE) begin : g_bytemask
-         for (gi = 0; gi < DW/8; gi = gi + 1) begin : g_lane
-            assign wmask_a_int[gi*8+:8] = {8{wmask_a[gi*8]}};
-            assign wmask_b_int[gi*8+:8] = {8{wmask_b[gi*8]}};
-         end
-      end
-      else begin : g_passthru
-         assign wmask_a_int = wmask_a;
-         assign wmask_b_int = wmask_b;
-      end
-   endgenerate
 
    la_tdpram_impl #(.DW      (DW),
                     .AW      (AW),
-                    .BYTEMODE(BYTEMODE),
+                    .BYTEMASK(BYTEMASK),
                     .PROP    (PROP),
                     .CTRLW   (CTRLW),
                     .STATUSW (STATUSW))
-   memory (// a port
+   memory (// A port
            .clk_a      (clk_a),
            .ce_a       (ce_a),
            .we_a       (we_a),
-           .wmask_a    (wmask_a_int),
+           .wmask_a    (wmask_a),
            .addr_a     (addr_a),
            .din_a      (din_a),
            .dout_a     (dout_a),
-           // b port
+           // B port
            .clk_b      (clk_b),
            .ce_b       (ce_b),
            .we_b       (we_b),
-           .wmask_b    (wmask_b_int),
+           .wmask_b    (wmask_b),
            .addr_b     (addr_b),
            .din_b      (din_b),
            .dout_b     (dout_b),
-            // macro interface
+            // Macro interface
            .selctrl    (selctrl),
            .ctrl       (ctrl),
            .status     (status));

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -54,9 +54,10 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
    reg [DW-1:0]       ram[(2**AW)-1:0];
    /* verilator lint_on MULTIDRIVEN */
 
-   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
-   // mask bit across its 8-bit lane to form byte-uniform DW-wide masks for
-   // the reference model. Bit mode passes the per-bit masks through.
+`ifdef VERILATOR
+   // Fast equivalent ram write model (for ultra wide RAMs). The vectorized
+   // AND/OR needs full DW-wide bit masks, so byte mode replicates each mask
+   // bit across its 8-bit lane; bit mode passes the per-bit masks through.
    wire [DW-1:0] wmask_a_int;
    wire [DW-1:0] wmask_b_int;
    genvar gwm;
@@ -73,8 +74,6 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
       end
    endgenerate
 
-`ifdef VERILATOR
-   // Fast equivalent ram write model (for ultra wide RAMs)
    always @(posedge clk_a)
      if (ce_a & we_a)
        ram[addr_a] <= (din_a & wmask_a_int) | (ram[addr_a] & ~wmask_a_int);
@@ -83,9 +82,8 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
        ram[addr_b] <= (din_b & wmask_b_int) | (ram[addr_b] & ~wmask_b_int);
 `else
    // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
-   // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
-   // In byte mode the masks are byte-uniform (replicated above) and DW
-   // must be a multiple of 8.
+   // granularity: per 8-bit lane (byte-wide BRAM) or per-bit (hard macro).
+   // In byte mode the masks are DW/8-wide and DW must be a multiple of 8.
 
    // Port A write
    generate
@@ -94,7 +92,7 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk_a)
            if (ce_a & we_a)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask_a_int[i*8])
+               if (wmask_a[i])
                  ram[addr_a][i*8+:8] <= din_a[i*8+:8];
       end
       else begin : g_bitmask_a
@@ -102,7 +100,7 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk_a)
            if (ce_a & we_a)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask_a_int[i])
+               if (wmask_a[i])
                  ram[addr_a][i] <= din_a[i];
       end
    endgenerate
@@ -114,7 +112,7 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk_b)
            if (ce_b & we_b)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask_b_int[i*8])
+               if (wmask_b[i])
                  ram[addr_b][i*8+:8] <= din_b[i*8+:8];
       end
       else begin : g_bitmask_b
@@ -122,7 +120,7 @@ module la_tdpram_impl #(parameter DW = 32,          // memory width
          always @(posedge clk_b)
            if (ce_b & we_b)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask_b_int[i])
+               if (wmask_b[i])
                  ram[addr_b][i] <= din_b[i];
       end
    endgenerate

--- a/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
+++ b/lambdalib/ramlib/la_tdpram/rtl/la_tdpram_impl.v
@@ -20,62 +20,81 @@
  *
  ****************************************************************************/
 
-module la_tdpram_impl #(parameter DW = 32,          // Memory width
-                        parameter AW = 10,          // Address width (derived)
-                        parameter BYTEMODE = 0,     // 1=byte mask, 0=bit mask
+module la_tdpram_impl #(parameter DW = 32,          // memory width
+                        parameter AW = 10,          // address width
+                        parameter BYTEMASK = 0,     // 1=byte mask, 0=bit mask
                         parameter PROP = "DEFAULT", // variable for hard macro
                         parameter CTRLW = 32,       // width of ctrl interface
                         parameter STATUSW = 32      // width of status interface
                         )
    (// A port
-    input               clk_a,   // write clock
-    input               ce_a,    // write chip-enable
-    input               we_a,    // write enable
-    input [DW-1:0]      wmask_a, // write mask
-    input [AW-1:0]      addr_a,  // write address
-    input [DW-1:0]      din_a,   // write data in
-    output reg [DW-1:0] dout_a,  // read data out
+    input                              clk_a,   // write clock
+    input                              ce_a,    // write chip-enable
+    input                              we_a,    // write enable
+    input [(BYTEMASK?DW/8:DW)-1:0]     wmask_a, // bit or byte write mask
+    input [AW-1:0]                     addr_a,  // write address
+    input [DW-1:0]                     din_a,   // write data in
+    output reg [DW-1:0]                dout_a,  // read data out
     // B port
-    input               clk_b,   // write clock
-    input               ce_b,    // write chip-enable
-    input               we_b,    // write enable
-    input [DW-1:0]      wmask_b, // write mask
-    input [AW-1:0]      addr_b,  // write address
-    input [DW-1:0]      din_b,   // write data in
-    output reg [DW-1:0] dout_b,  // read data out
+    input                              clk_b,   // write clock
+    input                              ce_b,    // write chip-enable
+    input                              we_b,    // write enable
+    input [(BYTEMASK ? DW/8 : DW)-1:0] wmask_b, // bit or byte write mask
+    input [AW-1:0]                     addr_b,  // write address
+    input [DW-1:0]                     din_b,   // write data in
+    output reg [DW-1:0]                dout_b,  // read data out
     // Technology interfaces
-    input               selctrl, // selects control interface
-    input [CTRLW-1:0]   ctrl,    // pass through control interface
-    output [STATUSW-1:0] status   // pass through status interface
+    input                              selctrl, // selects control interface
+    input [CTRLW-1:0]                  ctrl,    // control interface
+    output [STATUSW-1:0]               status   // status interface
     );
 
-    // Generic RTL RAM
+   // Generic RTL RAM
    /* verilator lint_off MULTIDRIVEN */
    reg [DW-1:0]       ram[(2**AW)-1:0];
    /* verilator lint_on MULTIDRIVEN */
+
+   // Byte mode delivers a DW/8-wide mask (one bit per byte); replicate each
+   // mask bit across its 8-bit lane to form byte-uniform DW-wide masks for
+   // the reference model. Bit mode passes the per-bit masks through.
+   wire [DW-1:0] wmask_a_int;
+   wire [DW-1:0] wmask_b_int;
+   genvar gwm;
+   generate
+      if (BYTEMASK) begin : g_wm_byte
+         for (gwm = 0; gwm < DW/8; gwm = gwm + 1) begin : g_wm_lane
+            assign wmask_a_int[gwm*8+:8] = {8{wmask_a[gwm]}};
+            assign wmask_b_int[gwm*8+:8] = {8{wmask_b[gwm]}};
+         end
+      end
+      else begin : g_wm_bit
+         assign wmask_a_int = wmask_a;
+         assign wmask_b_int = wmask_b;
+      end
+   endgenerate
 
 `ifdef VERILATOR
    // Fast equivalent ram write model (for ultra wide RAMs)
    always @(posedge clk_a)
      if (ce_a & we_a)
-       ram[addr_a] <= (din_a & wmask_a) | (ram[addr_a] & ~wmask_a);
+       ram[addr_a] <= (din_a & wmask_a_int) | (ram[addr_a] & ~wmask_a_int);
    always @(posedge clk_b)
      if (ce_b & we_b)
-       ram[addr_b] <= (din_b & wmask_b) | (ram[addr_b] & ~wmask_b);
+       ram[addr_b] <= (din_b & wmask_b_int) | (ram[addr_b] & ~wmask_b_int);
 `else
-   // FPGA synthesis friendly RAM pattern. BYTEMODE selects the write
-   // granularity: per-bit (hard macro / per-bit BRAM such as ice40) or per
-   // 8-bit lane (byte-wide BRAM). In byte mode the masks are byte-uniform (the
-   // la_tdpram wrapper replicates wmask_x[i*8]) and DW must be a multiple of 8.
+   // FPGA synthesis friendly RAM pattern. BYTEMASK selects the write
+   // granularity: per-bit (hard macro) or per 8-bit lane (byte-wide BRAM).
+   // In byte mode the masks are byte-uniform (replicated above) and DW
+   // must be a multiple of 8.
 
    // Port A write
    generate
-      if (BYTEMODE) begin : g_bytemask_a
+      if (BYTEMASK) begin : g_bytemask_a
          integer i;
          always @(posedge clk_a)
            if (ce_a & we_a)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask_a[i*8])
+               if (wmask_a_int[i*8])
                  ram[addr_a][i*8+:8] <= din_a[i*8+:8];
       end
       else begin : g_bitmask_a
@@ -83,19 +102,19 @@ module la_tdpram_impl #(parameter DW = 32,          // Memory width
          always @(posedge clk_a)
            if (ce_a & we_a)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask_a[i])
+               if (wmask_a_int[i])
                  ram[addr_a][i] <= din_a[i];
       end
    endgenerate
 
    // Port B write
    generate
-      if (BYTEMODE) begin : g_bytemask_b
+      if (BYTEMASK) begin : g_bytemask_b
          integer i;
          always @(posedge clk_b)
            if (ce_b & we_b)
              for (i = 0; i < DW/8; i = i + 1)
-               if (wmask_b[i*8])
+               if (wmask_b_int[i*8])
                  ram[addr_b][i*8+:8] <= din_b[i*8+:8];
       end
       else begin : g_bitmask_b
@@ -103,7 +122,7 @@ module la_tdpram_impl #(parameter DW = 32,          // Memory width
          always @(posedge clk_b)
            if (ce_b & we_b)
              for (i = 0; i < DW; i = i + 1)
-               if (wmask_b[i])
+               if (wmask_b_int[i])
                  ram[addr_b][i] <= din_b[i];
       end
    endgenerate


### PR DESCRIPTION
- BYTEMODE --> BYTEMASK name change
- Making wmask consistent with BYTEMASK, ie.when BYTEMASK is set, then the wmask shouldbe DW/8
- Making sure the _impl is consistent with top, must be pass through, moving bit replication into _impl.
- cosmetic cleanups